### PR TITLE
Notification Job

### DIFF
--- a/src/Shiny.Notifications/Platforms/Shared/NotificationJob.cs
+++ b/src/Shiny.Notifications/Platforms/Shared/NotificationJob.cs
@@ -27,13 +27,15 @@ namespace Shiny.Notifications
             var all = await this.repository.GetAll<Notification>();
             var pending = all.Where(x => x.ScheduleDate.Value < DateTime.UtcNow);
 
+            var anyPending = false;
             foreach (var notification in pending)
             {
+                anyPending = true;
                 notification.ScheduleDate = null; // slight hack, kill schedule date as we're triggering now
                 await this.manager.Send(notification);
                 await this.repository.Remove<Notification>(notification.Id.ToString());
             }
-            return pending.Any();
+            return anyPending;
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###

Fixes `InvalidOperationException` after sending scheduled notifications. Error is due to accessing `ScheduleDate.Value` again after it has been set to `null`.

### Issues Resolved ### 

<img src="https://user-images.githubusercontent.com/133987/61324226-8b657480-a7d7-11e9-97f5-eb28adf9a12f.png" width="270" />


### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 None

### Platforms Affected ### 

- Android
- UWP

### Behavioral Changes ###

None

### Testing Procedure ###

Have not actually tested, but the error is easily reproduced by scheduling a job with Shiny Sample. Any tips on connecting Shiny Sample with a local build of Shiny?

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard