### PR TITLE
Locations Cleanup

### DIFF
--- a/src/Shiny.Locations/Distance.cs
+++ b/src/Shiny.Locations/Distance.cs
@@ -32,6 +32,10 @@ namespace Shiny.Locations
         {
             TotalKilometers = miles * MILES_TO_KM
         };
+        public static Distance FromMiles(double miles) => new Distance
+        {
+            TotalKilometers = miles * MILES_TO_KM
+        };
         public static Distance FromMeters(double meters) => new Distance
         {
             TotalKilometers = meters / KM_TO_METERS

--- a/src/Shiny.Locations/Distance.cs
+++ b/src/Shiny.Locations/Distance.cs
@@ -1,9 +1,8 @@
 ﻿using System;
 
-
 namespace Shiny.Locations
 {
-    public sealed class Distance
+    public sealed class Distance : IEquatable<Distance>
     {
         public const double MILES_TO_KM = 1.60934;
         public const double KM_TO_MILES = 0.621371;
@@ -11,12 +10,12 @@ namespace Shiny.Locations
 
 
         public double TotalMiles => this.TotalKilometers * KM_TO_MILES;
-        public double TotalMeters => this.TotalKilometers * 1000;
+        public double TotalMeters => this.TotalKilometers * KM_TO_METERS;
         public double TotalKilometers { get; set; }
 
 
-        public override string ToString() => $"[Distance: {this.TotalKilometers}]";
-        public bool Equals(Distance other) => (this.TotalKilometers) == (other.TotalKilometers);
+        public override string ToString() => $"[Distance: {this.TotalKilometers} km]";
+        public bool Equals(Distance other) => (this.TotalKilometers) == (other?.TotalKilometers);
         public override bool Equals(object obj) => obj is Distance distance && this.Equals(distance);
         public override int GetHashCode() => (this.TotalKilometers).GetHashCode();
 

--- a/src/Shiny.Locations/GeofenceRegion.cs
+++ b/src/Shiny.Locations/GeofenceRegion.cs
@@ -3,7 +3,7 @@
 
 namespace Shiny.Locations
 {
-    public class GeofenceRegion
+    public class GeofenceRegion : IEquatable<GeofenceRegion>
     {
         public GeofenceRegion(string identifier,
                               Position center,
@@ -24,9 +24,9 @@ namespace Shiny.Locations
         public bool NotifyOnExit { get; set; } = true;
 
         public override string ToString() => $"[Identifier: {this.Identifier}]";
-        public bool Equals(GeofenceRegion other) => (this.Identifier) == (other.Identifier);
+        public bool Equals(GeofenceRegion other) => (this.Identifier) == (other?.Identifier);
         public override bool Equals(object obj) => obj is GeofenceRegion region && this.Equals(region);
-        public override int GetHashCode() => (this.Identifier).GetHashCode();
+        public override int GetHashCode() => (this.Identifier)?.GetHashCode() ?? 0;
 
         public static bool operator ==(GeofenceRegion left, GeofenceRegion right) => Equals(left, right);
         public static bool operator !=(GeofenceRegion left, GeofenceRegion right) => !Equals(left, right);

--- a/src/Shiny.Locations/Platforms/Android/GeofenceManagerImpl.cs
+++ b/src/Shiny.Locations/Platforms/Android/GeofenceManagerImpl.cs
@@ -5,12 +5,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
-using Android.Gms.Extensions;
 using Android.Gms.Location;
 using Android;
 using Android.App;
 using Android.Content;
-using static Android.Manifest;
 using Shiny.Infrastructure;
 using Shiny.Logging;
 
@@ -96,7 +94,7 @@ namespace Shiny.Locations
         public override async Task StopMonitoring(GeofenceRegion region)
         {
             await this.Repository.Remove(region.Identifier);
-            await this.client.RemoveGeofences(new List<string> { region.Identifier });
+            await this.client.RemoveGeofencesAsync(new List<string> { region.Identifier });
         }
 
 
@@ -104,7 +102,7 @@ namespace Shiny.Locations
         {
             var regions = await this.Repository.GetAll();
             var regionIds = regions.Select(x => x.Identifier).ToArray();
-            await this.client.RemoveGeofences(regionIds);
+            await this.client.RemoveGeofencesAsync(regionIds);
             await this.Repository.Clear();
         }
 
@@ -141,7 +139,7 @@ namespace Shiny.Locations
                 .SetInitialTrigger(transitions)
                 .Build();
 
-            await this.client.AddGeofences(
+            await this.client.AddGeofencesAsync(
                 request,
                 this.GetPendingIntent()
             );

--- a/src/Shiny.Locations/Position.cs
+++ b/src/Shiny.Locations/Position.cs
@@ -3,7 +3,7 @@
 
 namespace Shiny.Locations
 {
-    public class Position
+    public class Position : IEquatable<Position>
     {
         public Position(double lat, double lng)
         {
@@ -37,21 +37,7 @@ namespace Shiny.Locations
 
 
         public override string ToString() => $"Latitude: {this.Latitude} - Longitude: {this.Longitude}";
-        //public bool Equals(Position other)
-        //{
-        //    if (other == null)
-        //        return false;
-
-        //    if (this.Latitude != other.Latitude)
-        //        return false;
-
-        //    if (this.Longitude != other.Longitude)
-        //        return false;
-
-        //    return false;
-        //}
-
-        public bool Equals(Position other) => (this.Latitude, this.Longitude).Equals((other?.Latitude, other?.Longitude));
+        public bool Equals(Position other) => other != null && (this.Latitude, this.Longitude).Equals((other.Latitude, other.Longitude));
         public static bool operator ==(Position left, Position right) => Equals(left, right);
         public static bool operator !=(Position left, Position right) => !Equals(left, right);
         public override bool Equals(object obj) => obj is Position pos && this.Equals(pos);

--- a/tests/Shiny.Device.Tests.Shared/TestStartup.cs
+++ b/tests/Shiny.Device.Tests.Shared/TestStartup.cs
@@ -6,7 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Shiny.Device.Tests
 {
-    public class TestStartup : Startup
+    public class TestStartup : ShinyStartup
     {
         public override void ConfigureServices(IServiceCollection services)
         {

--- a/tests/Shiny.Tests/Locations/DistanceTests.cs
+++ b/tests/Shiny.Tests/Locations/DistanceTests.cs
@@ -18,9 +18,18 @@ namespace Shiny.Tests.Locations
 
 
         [Fact]
-        public void MilesToKm() =>
+        public void Int32MilesToKm() =>
             Distance
                 .FromMiles(2)
+                .TotalKilometers
+                .Should()
+                .Be(3.21868);
+
+
+        [Fact]
+        public void DoubleMilesToKm() =>
+            Distance
+                .FromMiles(2.0)
                 .TotalKilometers
                 .Should()
                 .Be(3.21868);

--- a/tests/Shiny.Tests/Locations/DistanceTests.cs
+++ b/tests/Shiny.Tests/Locations/DistanceTests.cs
@@ -42,5 +42,32 @@ namespace Shiny.Tests.Locations
                 .TotalMiles
                 .Should()
                 .Be(1.242742);
+
+
+        [Fact]
+        public void EqualsDistance() =>
+            Distance
+                .FromKilometers(1)
+                .Equals(Distance.FromMeters(1000))
+                .Should()
+                .Be(true);
+
+
+        [Fact]
+        public void EqualsNull() =>
+            Distance
+                .FromKilometers(1)
+                .Equals(null)
+                .Should()
+                .Be(false);
+
+
+        [Fact]
+        public void ToStringReturnsKilometers() =>
+            Distance
+                .FromKilometers(1)
+                .ToString()
+                .Should()
+                .Be("[Distance: 1 km]");
     }
 }

--- a/tests/Shiny.Tests/Locations/GeofenceRegionTests.cs
+++ b/tests/Shiny.Tests/Locations/GeofenceRegionTests.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Shiny.Locations;
+using FluentAssertions;
+using Xunit;
+
+
+namespace Shiny.Tests.Locations
+{
+    public class GeofenceRegionTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("test")]
+        public void GetHashCodeConsidersOnlyIdentifier(string id) =>
+            new GeofenceRegion(id, new Position(0, 0), Distance.FromKilometers(0))
+                .GetHashCode()
+                .Should()
+                .Be(new GeofenceRegion(id, null, null).GetHashCode());
+
+
+        [Theory]
+        [InlineData(null, null, true)]
+        [InlineData("test", null, false)]
+        [InlineData(null, "test", false)]
+        [InlineData("test", "test", true)]
+        public void EqualsComparesIdentifier(string id1, string id2, bool expected) =>
+            new GeofenceRegion(id1, null, null)
+                .Equals(new GeofenceRegion(id2, null, null))
+                .Should()
+                .Be(expected);
+
+
+        [Fact]
+        public void ToStringReturnsIdentifier() =>
+            new GeofenceRegion("test", null, null)
+                .ToString()
+                .Should()
+                .Be("[Identifier: test]");
+    }
+}

--- a/tests/Shiny.Tests/Locations/PositionTests.cs
+++ b/tests/Shiny.Tests/Locations/PositionTests.cs
@@ -8,11 +8,16 @@ namespace Shiny.Tests.Locations
 {
     public class PositionTests
     {
+        const double lat0 = 43.6429228;
+        const double lng0 = -79.3789959;
+        const double lat1 = 43.6411314;
+        const double lng1 = -79.3808415;
+
         [Fact]
         public void Inside_Geofence()
         {
-            var current = new Position(43.6429228, -79.3789959); // union station
-            var center = new Position(43.6411314, -79.3808415); // 88 queen's quay
+            var current = new Position(lat0, lng0); // union station
+            var center = new Position(lat1, lng1); // 88 queen's quay
             var distance = center.GetDistanceTo(current);
 
             var region = new GeofenceRegion("test", center, Distance.FromKilometers(3));
@@ -27,7 +32,7 @@ namespace Shiny.Tests.Locations
         [Fact]
         public void Outside_Geofence()
         {
-            var center = new Position(43.6411314, -79.3808415); // 88 queen's quay
+            var center = new Position(lat1, lng1); // 88 queen's quay
             var current = new Position(43.6515754, -79.3492364); // random point outside fence
             var region = new GeofenceRegion("test", center, Distance.FromKilometers(2));
 
@@ -36,5 +41,45 @@ namespace Shiny.Tests.Locations
                 .Should()
                 .Be(false);
         }
+
+
+        [Theory]
+        [InlineData(lat0, lng0, lat0, lng0, true)]
+        [InlineData(lat0, lng0, lat1, lng0, false)]
+        [InlineData(lat0, lng0, lat0, lng1, false)]
+        [InlineData(lat0, lng0, lat1, lng1, false)]
+        public void EqualsPosition(double lat1, double lng1, double lat2, double lng2, bool expected) =>
+            new Position(lat1, lng1)
+                .Equals(new Position(lat2, lng2))
+                .Should()
+                .Be(expected);
+
+
+        [Fact]
+        public void EqualsNull() =>
+            new Position(lat0, lng0)
+                .Equals(null)
+                .Should()
+                .Be(false);
+
+
+        [Theory]
+        [InlineData(lat0, lng0, lat0, lng0, true)]
+        [InlineData(lat0, lng0, lat1, lng0, false)]
+        [InlineData(lat0, lng0, lat0, lng1, false)]
+        public void GetHashCodeConsidersLatitudeAndLongitude(double lat1, double lng1, double lat2, double lng2, bool expected) =>
+            new Position(lat1, lng1)
+                .GetHashCode()
+                .Equals(new Position(lat2, lng2).GetHashCode())
+                .Should()
+                .Be(expected);
+
+
+        [Fact]
+        public void ToStringReturnsLatitudeAndLongitude() =>
+            new Position(lat0, lng0)
+                .ToString()
+                .Should()
+                .Be($"Latitude: {lat0} - Longitude: {lng0}");
     }
 }


### PR DESCRIPTION
### Description of Change ###

1. Generally adds tests for Locations and fixes subtle bugs I noticed while skimming the project.
2. Fixes build error due to `ShinyStartup` rename
3. Changes a few places `await` was used on methods returning `Android.Gms.Tasks.Task` to use presumably equivalent methods returning .NET `Task`

### Issues Resolved ### 

- `distance.Equals(null)` NRE
- `geofenceRegion.Equals(null)` NRE
- `geofenceRegion.GetHashCode()` NRE for `null` identifier
- `position1.Equals(position2)` never `true`

### API Changes ###

- Added `Distance.FromMiles(double)`
  - Should `FromMiles(int)` be marked `[Obsolete]`?

### Platforms Affected ### 

- All (most changes)
- Android (GMS async change)

### Behavioral Changes ###

None

### Testing Procedure ###

Shiny.Tests.Locations are all passing. (Note: Shiny.Tests.Beacons and Shiny.Tests.Infrastructure fail for me locally.)

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard