### PR TITLE
Check Geofence Error

### DIFF
--- a/src/Shiny.Locations/LocationLogCategory.cs
+++ b/src/Shiny.Locations/LocationLogCategory.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+
+namespace Shiny.Locations
+{
+    public static class LocationLogCategory
+    {
+        public const string Geofence = nameof(Geofence);
+    }
+}

--- a/src/Shiny.Locations/Platforms/Android/GeofenceProcessor.cs
+++ b/src/Shiny.Locations/Platforms/Android/GeofenceProcessor.cs
@@ -38,6 +38,9 @@ namespace Shiny.Locations
                 return;
             }
 
+            if (e.TriggeringGeofences == null)
+                return;
+
             foreach (var triggeringGeofence in e.TriggeringGeofences)
             {
                 var state = (GeofenceState)e.GeofenceTransition;

--- a/src/Shiny.Locations/Platforms/Android/GeofenceProcessor.cs
+++ b/src/Shiny.Locations/Platforms/Android/GeofenceProcessor.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Android.Content;
 using Android.Gms.Location;
 using Shiny.Infrastructure;
+using Shiny.Logging;
 
 
 namespace Shiny.Locations
@@ -29,6 +30,13 @@ namespace Shiny.Locations
             var e = GeofencingEvent.FromIntent(intent);
             if (e == null)
                 return;
+
+            if (e.HasError)
+            {
+                Log.Write(LocationLogCategory.Geofence, "Event Error",
+                    ("ErrorCode", GeofenceStatusCodes.GetStatusCodeString(e.ErrorCode)));
+                return;
+            }
 
             foreach (var triggeringGeofence in e.TriggeringGeofences)
             {


### PR DESCRIPTION
### Description of Change ###

- Check [`GeofencingEvent.HasError`](https://developers.google.com/android/reference/com/google/android/gms/location/GeofencingEvent.html#hasError()) and log `ErrorCode` if appropriate
- Log if `GeofenceEvent.RequestId` isn't found
- Log error from processing triggered geofence

### Issues Resolved ### 

- Fixes #37

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral Changes ###

None

### Testing Procedure ###

It compiles.

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard