### PR TITLE
Fix RequestState for iOS timeout.

### DIFF
--- a/src/Shiny.Locations/Platforms/iOS/GeofenceManagerImpl.cs
+++ b/src/Shiny.Locations/Platforms/iOS/GeofenceManagerImpl.cs
@@ -33,7 +33,8 @@ namespace Shiny.Locations
         {
             var task = this.gdelegate
                 .WhenStateDetermined()
-                .Where(x => region.Equals(x))
+                .Where(x => region.Equals(x.Region))
+                .Take(1)
                 .Select(x => x.Status)
                 .Timeout(TimeSpan.FromSeconds(20))
                 .ToTask(cancelToken);


### PR DESCRIPTION
### Description of Change ###

- Updated Where lambda to compare the Region property of GeofenceCurrentStatus instead of the GeofenceCurrentStatus object itself
- Added Take to ensure the Observable returns a value instead of timing out

### Issues Resolved ### 

- RequestState for the iOS implementation was always throwing a TimeOutException

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->
Tested on iPhone with iOS 12.3.1. Set breakpoints to determine that GeofenceState was returning from RequestState after the updates.

### PR Checklist ###

- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard