### PR TITLE
Log: Differentiate Job/Task Start and Success

### DIFF
--- a/src/Shiny.Core/Jobs/AbstractJobManager.cs
+++ b/src/Shiny.Core/Jobs/AbstractJobManager.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 using Shiny.Infrastructure;
 using Shiny.Logging;
 using Shiny.Net;
@@ -207,7 +206,7 @@ namespace Shiny.Jobs
                                       Exception exception = null)
         {
             if (exception == null)
-                Log.Write("Jobs", "Job Success", ("JobName", job.Identifier));
+                Log.Write("Jobs", state == JobState.Finish ? "Job Success" : $"Job ${state}", ("JobName", job.Identifier));
             else
                 Log.Write(exception, ("JobName", job.Identifier));
         }
@@ -216,7 +215,7 @@ namespace Shiny.Jobs
         protected virtual void LogTask(JobState state, string taskName, Exception exception = null)
         {
             if (exception == null)
-                Log.Write("Jobs", "Task Success", ("TaskName", taskName));
+                Log.Write("Jobs", state == JobState.Finish ? "Task Success" : $"Task ${state}", ("TaskName", taskName));
             else
                 Log.Write(exception, ("TaskName", taskName));
         }


### PR DESCRIPTION
### Description of Change ###

Jobs/Tasks now log Start/Success instead of Success twice.

### Platforms Affected ### 

- All

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard