### PR TITLE
Update BleCentralShinyModule.cs

### DIFF
--- a/src/Shiny.BluetoothLE/Central/Platforms/Android/BleCentralShinyModule.cs
+++ b/src/Shiny.BluetoothLE/Central/Platforms/Android/BleCentralShinyModule.cs
@@ -13,7 +13,7 @@ namespace Shiny.BluetoothLE.Central
 
         public override void Register(IServiceCollection services)
         {
-            if (this.config == null)
+            if (this.config != null)
                 services.AddSingleton(this.config);
 
             services.AddSingleton<CentralContext>();


### PR DESCRIPTION
Probably a typo, no point adding a null to services. 
AddSingleton Triggers null exception on init of BleCentralShinyModule.

### Description of Change ###
Fix on typo

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- All
- iOS
- Android
- UWP

### Behavioral Changes ###
Shoud prevent crash... 

None

### Testing Procedure ###
Should not crash 

### PR Checklist ###

- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard