### PR TITLE
Accept JsonSerializerSettings

### DIFF
--- a/src/Shiny.Core/Infrastructure/JsonNetSerializer.cs
+++ b/src/Shiny.Core/Infrastructure/JsonNetSerializer.cs
@@ -6,8 +6,14 @@ namespace Shiny.Infrastructure
 {
     public class JsonNetSerializer : ISerializer
     {
-        public T Deserialize<T>(string value) => JsonConvert.DeserializeObject<T>(value);
-        public object Deserialize(Type objectType, string value) => JsonConvert.DeserializeObject(value, objectType);
-        public string Serialize(object value) => JsonConvert.SerializeObject(value);
+        readonly JsonSerializerSettings settings;
+
+        public JsonNetSerializer() { }
+
+        public JsonNetSerializer(JsonSerializerSettings settings) => this.settings = settings;
+
+        public T Deserialize<T>(string value) => JsonConvert.DeserializeObject<T>(value, this.settings);
+        public object Deserialize(Type objectType, string value) => JsonConvert.DeserializeObject(value, objectType, this.settings);
+        public string Serialize(object value) => JsonConvert.SerializeObject(value, this.settings);
     }
 }


### PR DESCRIPTION
### Description of Change ###

Adds optional `JsonNetSerializer` constructor that accepts `JsonSerializerSettings`. Default constructor leaves `settings = null`, which aligns with internal behavior:

https://github.com/JamesNK/Newtonsoft.Json/blob/23be46f665887c9be03faf7864ae98890ca08246/Src/Newtonsoft.Json/JsonConvert.cs#L528-L531

Eliminates need to replicate the entire class to customize serialization.

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 New constructor; no breaking changes.

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- All

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard