### PR TITLE
When starting geofence regions are null or empty, do not request the …

### DIFF
--- a/src/Shiny.Locations/Platforms/Shared/GeofenceModule.cs
+++ b/src/Shiny.Locations/Platforms/Shared/GeofenceModule.cs
@@ -33,7 +33,7 @@ namespace Shiny.Locations
         public override async void OnContainerReady(IServiceProvider services)
         {
             base.OnContainerReady(services);
-            if (this.startingRegions == null)
+            if (this.startingRegions.IsEmpty())
                 return;
 
             try


### PR DESCRIPTION
…location permission

### Description of Change ###

Currently when configuring the Geofencing service in startup by services.UseGeofencing<LocationDelegates>() with empty starting geofencing regions, the library will automatically request the location permission.

The change will skip the location request in case of null or empty starting geofencing regions.


### Issues Resolved ### 
In some cases, the app will only ask location permission before the app is going to require the Location or Geofencing capabilities. Before the change, I have to explicitly call "services.UseGeofencing<LocationDelegates>(null)". It did take me about 2 hours to figure out from the original source code.

- fixes #

### API Changes ### 
 None

### Platforms Affected ### 
- All
- iOS
- Android
- UWP

### Behavioral Changes ###

When set up Genfencing with empty starting regions, services.UseGeofencing<LocationDelegates>(), the Shiny library will NOT request the location permission.

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard