### PR TITLE
Fix the Set method in SqliteRepository

### DIFF
--- a/src/Shiny.Integrations.Sqlite/SqliteRepository.cs
+++ b/src/Shiny.Integrations.Sqlite/SqliteRepository.cs
@@ -89,7 +89,14 @@ namespace Shiny.Integrations.Sqlite
 
         public async Task<bool> Set(string key, object entity)
         {
-            var item = await this.conn.GetAsync<RepoStore>(key);
+            if (entity == null)
+                return false;
+
+            var item = await this.conn.RepoItems.FirstOrDefaultAsync(x =>
+                    x.Key == key &&
+                    x.TypeName == entity.GetType().AssemblyQualifiedName
+                    );
+
             if (item == null)
             {
                 await this.conn.InsertAsync(new RepoStore


### PR DESCRIPTION
### Description of Change ###

Fix the Set method in SqliteRepository

### Issues Resolved ### 

When turning on the Sqlite storage by "services.UseSqliteStorage()", an exception was thrown from SqliteRepository.Set(string key, object entity) when attempting to save data to the repository  because of the bug from the method.

### API Changes ###
 None

### Platforms Affected ### 
- All

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard