### PR TITLE
fix : request permission from user for recording audio

### DIFF
--- a/src/Shiny.SpeechRecognition/Platforms/Android/SpeechRecognizerImpl.cs
+++ b/src/Shiny.SpeechRecognition/Platforms/Android/SpeechRecognizerImpl.cs
@@ -17,7 +17,7 @@ namespace Shiny.SpeechRecognition
 
         public SpeechRecognizerImpl(AndroidContext context) => this.context = context;
 
-        public override Task<AccessState> RequestAccess()
+        public override async Task<AccessState> RequestAccess()
         {
             var state = AccessState.Available;
             if (!SpeechRecognizer.IsRecognitionAvailable(this.context.AppContext))
@@ -25,8 +25,11 @@ namespace Shiny.SpeechRecognition
 
             else if (!this.context.IsInManifest(Manifest.Permission.RecordAudio))
                 state = AccessState.NotSetup;
+            
+            else if (this.context.GetCurrentAccessState(Manifest.Permission.RecordAudio) == AccessState.Denied)
+                state = await this.context.RequestAccess(Manifest.Permission.RecordAudio);
 
-            return Task.FromResult(state);
+            return state;
         }
 
 


### PR DESCRIPTION
### Description of Change ###

Request for permission from user before recording audio for speech recognition.

### Issues Resolved ### 
The application would crash as permission was not granted. Following exception was caught 
```
**System.Exception:** 'Could not start speech recognizer - ERROR: InsufficientPermissions'
```

### API Changes ###
 
Change `RequestAccess()` method to async for Android implementation.

### Platforms Affected ### 
- Android

### Behavioral Changes ###

None

### Testing Procedure ###
1.  Call `RequestAccess` method of `SpeechRecognizer`
2. It returns `AccessState.Available` as it only checked if `SpeechRecognizer` was available and RecordAudio permission was in manifest.
3. Added additional check to find if user has manually granted `RecordAudio` permission, otherwise request the user for it.

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard