### PR TITLE
Android Notifications: When, ShowWhen, Color

### DIFF
--- a/src/Shiny.Notifications/AndroidOptions.cs
+++ b/src/Shiny.Notifications/AndroidOptions.cs
@@ -8,9 +8,9 @@ namespace Shiny.Notifications
         public static string DefaultChannelId { get; set; } = "shinynotificationchannelid";
         public static string DefaultChannel { get; set; } = "shinynotificationchannel";
         public static string DefaultSmallIconResourceName { get; set; } = "notification";
+        public static string? DefaultColorResourceName { get; set; }
         public static string DefaultChannelDescription { get; set; }
         public static AndroidNotificationImportance DefaultNotificationImportance { get; set; } = AndroidNotificationImportance.Default;
-        //public static Color? DefaultColor { get; set; }
         public static bool? DefaultShowWhen { get; set; }
         public static bool DefaultVibrate { get; set; }
         public static AndroidActivityFlags DefaultLaunchActivityFlags { get; set; } = AndroidActivityFlags.NewTask | AndroidActivityFlags.ClearTask;
@@ -18,12 +18,12 @@ namespace Shiny.Notifications
         public AndroidActivityFlags LaunchActivityFlags { get; set; } = DefaultLaunchActivityFlags;
         public bool Vibrate { get; set; } = DefaultVibrate;
         public int? Priority { get; set; }
-        //public Color? Color { get; set; } = DefaultColor; // API 21+
         public string ChannelId { get; set; } = DefaultChannelId;
         public string Channel { get; set; } = DefaultChannel;
         public string ChannelDescription { get; set; } = DefaultChannelDescription;
         public AndroidNotificationImportance NotificationImportance { get; set; } = DefaultNotificationImportance;
         public string SmallIconResourceName { get; set; } = DefaultSmallIconResourceName;
+        public string? ColorResourceName { get; set; } = DefaultColorResourceName;
         public bool OnGoing { get; set; }
         public bool AutoCancel { get; set; } = true;
         public bool? ShowWhen { get; set; } = DefaultShowWhen;

--- a/src/Shiny.Notifications/AndroidOptions.cs
+++ b/src/Shiny.Notifications/AndroidOptions.cs
@@ -11,6 +11,7 @@ namespace Shiny.Notifications
         public static string DefaultChannelDescription { get; set; }
         public static AndroidNotificationImportance DefaultNotificationImportance { get; set; } = AndroidNotificationImportance.Default;
         //public static Color? DefaultColor { get; set; }
+        public static bool? DefaultShowWhen { get; set; }
         public static bool DefaultVibrate { get; set; }
         public static AndroidActivityFlags DefaultLaunchActivityFlags { get; set; } = AndroidActivityFlags.NewTask | AndroidActivityFlags.ClearTask;
 
@@ -25,6 +26,8 @@ namespace Shiny.Notifications
         public string SmallIconResourceName { get; set; } = DefaultSmallIconResourceName;
         public bool OnGoing { get; set; }
         public bool AutoCancel { get; set; } = true;
+        public bool? ShowWhen { get; set; } = DefaultShowWhen;
+        public DateTime? When { get; set; }
     }
 
 

--- a/src/Shiny.Notifications/AndroidOptions.cs
+++ b/src/Shiny.Notifications/AndroidOptions.cs
@@ -9,7 +9,7 @@ namespace Shiny.Notifications
         public static string DefaultChannel { get; set; } = "shinynotificationchannel";
         public static string DefaultSmallIconResourceName { get; set; } = "notification";
         public static string? DefaultColorResourceName { get; set; }
-        public static string DefaultChannelDescription { get; set; }
+        public static string? DefaultChannelDescription { get; set; }
         public static AndroidNotificationImportance DefaultNotificationImportance { get; set; } = AndroidNotificationImportance.Default;
         public static bool? DefaultShowWhen { get; set; }
         public static bool DefaultVibrate { get; set; }
@@ -20,7 +20,7 @@ namespace Shiny.Notifications
         public int? Priority { get; set; }
         public string ChannelId { get; set; } = DefaultChannelId;
         public string Channel { get; set; } = DefaultChannel;
-        public string ChannelDescription { get; set; } = DefaultChannelDescription;
+        public string? ChannelDescription { get; set; } = DefaultChannelDescription;
         public AndroidNotificationImportance NotificationImportance { get; set; } = DefaultNotificationImportance;
         public string SmallIconResourceName { get; set; } = DefaultSmallIconResourceName;
         public string? ColorResourceName { get; set; } = DefaultColorResourceName;

--- a/src/Shiny.Notifications/NotificationLogCategory.cs
+++ b/src/Shiny.Notifications/NotificationLogCategory.cs
@@ -1,0 +1,7 @@
+﻿namespace Shiny.Notifications
+{
+    public class NotificationLogCategory
+    {
+        public const string Notifications = nameof(Notifications);
+    }
+}

--- a/src/Shiny.Notifications/Platforms/Android/NotificationManager.cs
+++ b/src/Shiny.Notifications/Platforms/Android/NotificationManager.cs
@@ -133,11 +133,18 @@ namespace Shiny.Notifications
             if (notification.BadgeCount != null)
                 builder.SetNumber(notification.BadgeCount.Value);
 
-            if ((int)Build.VERSION.SdkInt >= 21 && notification.Android.ColorResourceName != null)
+            if (notification.Android.ColorResourceName != null)
             {
-                var color = this.GetColor(notification.Android.ColorResourceName);
-                if (color != null)
-                    builder.SetColor(color.Value);
+                if (this.context.IsMinApiLevel(21))
+                {
+                    var color = this.GetColor(notification.Android.ColorResourceName);
+                    if (color != null)
+                        builder.SetColor(color.Value);
+                }
+                else
+                {
+                    Log.Write(NotificationLogCategory.Notifications, "ColorResourceName is only supported on API 21+");
+                }
             }
 
             if (notification.Android.Priority != null)

--- a/src/Shiny.Notifications/Platforms/Android/NotificationManager.cs
+++ b/src/Shiny.Notifications/Platforms/Android/NotificationManager.cs
@@ -235,7 +235,10 @@ namespace Shiny.Notifications
 
             var colorResourceId = this.context.GetColorByName(colorResourceName);
             if (colorResourceId <= 0)
-                throw new ArgumentException($"Color ResourceId for {colorResourceName} not found");
+            {
+                Log.Write(NotificationLogCategory.Notifications, $"Color ResourceId for {colorResourceName} not found");
+                return null;
+            }
 
             return ContextCompat.GetColor(this.context.AppContext, colorResourceId);
         }
@@ -247,7 +250,10 @@ namespace Shiny.Notifications
 
             var smallIconResourceId = this.context.GetResourceIdByName(notification.Android.SmallIconResourceName);
             if (smallIconResourceId <= 0)
-                throw new ArgumentException($"Icon ResourceId for {notification.Android.SmallIconResourceName} not found");
+            {
+                Log.Write(NotificationLogCategory.Notifications, $"Icon ResourceId for {notification.Android.SmallIconResourceName} not found");
+                return this.context.AppContext.ApplicationInfo.Icon;
+            }
 
             return smallIconResourceId;
         }

--- a/src/Shiny.Notifications/Platforms/Android/NotificationManager.cs
+++ b/src/Shiny.Notifications/Platforms/Android/NotificationManager.cs
@@ -7,6 +7,7 @@ using Android.App;
 using Android.Content;
 using Android.OS;
 using Android.Support.V4.App;
+using Android.Support.V4.Content;
 using Shiny.Infrastructure;
 using Shiny.Jobs;
 using Shiny.Logging;
@@ -132,8 +133,12 @@ namespace Shiny.Notifications
             if (notification.BadgeCount != null)
                 builder.SetNumber(notification.BadgeCount.Value);
 
-            //if ((int)Build.VERSION.SdkInt >= 21 && notification.Android.Color != null)
-            //    builder.SetColor(notification.Android.Color.Value)
+            if ((int)Build.VERSION.SdkInt >= 21 && notification.Android.ColorResourceName != null)
+            {
+                var color = this.GetColor(notification.Android.ColorResourceName);
+                if (color != null)
+                    builder.SetColor(color.Value);
+            }
 
             if (notification.Android.Priority != null)
                 builder.SetPriority(notification.Android.Priority.Value);
@@ -222,6 +227,18 @@ namespace Shiny.Notifications
             return pendingIntent;
         }
 
+
+        protected virtual int? GetColor(string colorResourceName)
+        {
+            if (colorResourceName.IsEmpty())
+                return null;
+
+            var colorResourceId = this.context.GetColorByName(colorResourceName);
+            if (colorResourceId <= 0)
+                throw new ArgumentException($"Color ResourceId for {colorResourceName} not found");
+
+            return ContextCompat.GetColor(this.context.AppContext, colorResourceId);
+        }
 
         protected virtual int GetIconResource(Notification notification)
         {

--- a/src/Shiny.Notifications/Platforms/Android/NotificationManager.cs
+++ b/src/Shiny.Notifications/Platforms/Android/NotificationManager.cs
@@ -235,10 +235,7 @@ namespace Shiny.Notifications
 
             var colorResourceId = this.context.GetColorByName(colorResourceName);
             if (colorResourceId <= 0)
-            {
-                Log.Write(NotificationLogCategory.Notifications, $"Color ResourceId for {colorResourceName} not found");
-                return null;
-            }
+                throw new ArgumentException($"Color ResourceId for {colorResourceName} not found");
 
             return ContextCompat.GetColor(this.context.AppContext, colorResourceId);
         }
@@ -250,10 +247,7 @@ namespace Shiny.Notifications
 
             var smallIconResourceId = this.context.GetResourceIdByName(notification.Android.SmallIconResourceName);
             if (smallIconResourceId <= 0)
-            {
-                Log.Write(NotificationLogCategory.Notifications, $"Icon ResourceId for {notification.Android.SmallIconResourceName} not found");
-                return this.context.AppContext.ApplicationInfo.Icon;
-            }
+                throw new ArgumentException($"Icon ResourceId for {notification.Android.SmallIconResourceName} not found");
 
             return smallIconResourceId;
         }

--- a/src/Shiny.Notifications/Platforms/Android/NotificationManager.cs
+++ b/src/Shiny.Notifications/Platforms/Android/NotificationManager.cs
@@ -138,6 +138,12 @@ namespace Shiny.Notifications
             if (notification.Android.Priority != null)
                 builder.SetPriority(notification.Android.Priority.Value);
 
+            if (notification.Android.ShowWhen != null)
+                builder.SetShowWhen(notification.Android.ShowWhen.Value);
+
+            if (notification.Android.When != null)
+                builder.SetWhen(notification.Android.When.Value.ToEpochMillis());
+
             if (notification.Android.Vibrate)
                 builder.SetVibrate(new long[] {500, 500});
 

--- a/src/Shiny.Notifications/Platforms/Android/NotificationManager.cs
+++ b/src/Shiny.Notifications/Platforms/Android/NotificationManager.cs
@@ -276,7 +276,7 @@ namespace Shiny.Notifications
             var category = this.registeredCategories.FirstOrDefault(x => x.Identifier.Equals(notification.Category));
             if (category == null)
             {
-                Log.Write("Notifications", "No notification category found for " + notification.Category);
+                Log.Write(NotificationLogCategory.Notifications, "No notification category found for " + notification.Category);
             }
             else
             {

--- a/src/Shiny.Notifications/Platforms/Android/NotificationManager.cs
+++ b/src/Shiny.Notifications/Platforms/Android/NotificationManager.cs
@@ -1,8 +1,8 @@
 using System;
-using System.Linq;
 using System.Collections.Generic;
-using System.Threading.Tasks;
+using System.Linq;
 using System.Reactive.Linq;
+using System.Threading.Tasks;
 using Android.App;
 using Android.Content;
 using Android.OS;
@@ -12,9 +12,9 @@ using Shiny.Infrastructure;
 using Shiny.Jobs;
 using Shiny.Logging;
 using Shiny.Settings;
-using TaskStackBuilder = Android.App.TaskStackBuilder;
 using Native = Android.App.NotificationManager;
 using RemoteInput = Android.Support.V4.App.RemoteInput;
+using TaskStackBuilder = Android.App.TaskStackBuilder;
 
 
 namespace Shiny.Notifications
@@ -52,7 +52,7 @@ namespace Shiny.Notifications
             //    .Where(x => x.Status == ActivityState.Created)
             //    .Subscribe(x => TryProcessIntent(x.Activity.Intent));
 
-            if ((int) Build.VERSION.SdkInt >= 26)
+            if ((int)Build.VERSION.SdkInt >= 26)
             {
                 this.newManager = Native.FromContext(context.AppContext);
             }
@@ -150,7 +150,7 @@ namespace Shiny.Notifications
                 builder.SetWhen(notification.Android.When.Value.ToEpochMillis());
 
             if (notification.Android.Vibrate)
-                builder.SetVibrate(new long[] {500, 500});
+                builder.SetVibrate(new long[] { 500, 500 });
 
             this.DoNotify(builder, notification);
             await this.services.SafeResolveAndExecute<INotificationDelegate>(x => x.OnReceived(notification));
@@ -286,7 +286,7 @@ namespace Shiny.Notifications
             }
             else
             {
-                var notificationString = this.serializer.Serialize(notification);                
+                var notificationString = this.serializer.Serialize(notification);
 
                 foreach (var action in category.Actions)
                 {
@@ -339,7 +339,7 @@ namespace Shiny.Notifications
             var pendingIntent = this.CreateActionIntent(notification, action);
             var iconId = this.context.GetResourceIdByName(action.Identifier);
             var nativeAction = new NotificationCompat.Action.Builder(iconId, action.Title, pendingIntent).Build();
-            
+
             return nativeAction;
         }
 

--- a/src/Shiny.Notifications/Platforms/Android/PlatformExtensions.cs
+++ b/src/Shiny.Notifications/Platforms/Android/PlatformExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Android.App;
+﻿using Android.App;
 using Android.Content;
 using Shiny.Notifications;
 
@@ -23,6 +22,15 @@ namespace Shiny
             return native;
         }
 
+
+        internal static int GetColorByName(this AndroidContext context, string colorName) => context
+            .AppContext
+            .Resources
+            .GetIdentifier(
+                colorName,
+                "color",
+                context.AppContext.PackageName
+            );
 
         internal static int GetResourceIdByName(this AndroidContext context, string iconName) => context
             .AppContext

--- a/src/Shiny.Notifications/Platforms/Shared/NotificationModule.cs
+++ b/src/Shiny.Notifications/Platforms/Shared/NotificationModule.cs
@@ -29,6 +29,7 @@ namespace Shiny.Notifications
                 AndroidOptions.DefaultChannelId = androidConfig.ChannelId ?? AndroidOptions.DefaultChannelId;
                 AndroidOptions.DefaultNotificationImportance = androidConfig.NotificationImportance;
                 AndroidOptions.DefaultLaunchActivityFlags = androidConfig.LaunchActivityFlags;
+                AndroidOptions.DefaultShowWhen = androidConfig.ShowWhen;
                 AndroidOptions.DefaultVibrate = androidConfig.Vibrate;
                 AndroidOptions.DefaultSmallIconResourceName = androidConfig.SmallIconResourceName ?? AndroidOptions.DefaultSmallIconResourceName;
             }

--- a/src/Shiny.Notifications/Platforms/Shared/NotificationModule.cs
+++ b/src/Shiny.Notifications/Platforms/Shared/NotificationModule.cs
@@ -32,6 +32,7 @@ namespace Shiny.Notifications
                 AndroidOptions.DefaultShowWhen = androidConfig.ShowWhen;
                 AndroidOptions.DefaultVibrate = androidConfig.Vibrate;
                 AndroidOptions.DefaultSmallIconResourceName = androidConfig.SmallIconResourceName ?? AndroidOptions.DefaultSmallIconResourceName;
+                AndroidOptions.DefaultColorResourceName = androidConfig.ColorResourceName;
             }
             if (uwpConfig != null)
                 UwpOptions.DefaultUseLongDuration = uwpConfig.UseLongDuration;


### PR DESCRIPTION
### Description of Change ###

Add `AndroidOptions` properties for:

- [`when`](https://developer.android.com/reference/android/app/Notification#when) ([`setWhen`](https://developer.android.com/reference/android/app/Notification.Builder.html#setWhen(long))/[`setShowWhen`](https://developer.android.com/reference/android/app/Notification.Builder.html#setShowWhen(boolean)))
- [`color`](https://developer.android.com/reference/android/app/Notification.html#color) ([`setColor`](https://developer.android.com/reference/android/app/Notification.Builder.html#setColor(int)))

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
- `Notifications.AndroidOptions` property changes:
  - Add `bool? ShowWhen`, `DateTime? When`, and `static bool? DefaultShowWhen`
  - Add `string? ColorResourceName` and `static string? DefaultColorResourceName`
  - Mark `ChannelDescription` and `DefaultChannelDescription` as nullable

### Platforms Affected ### 

- Android

### Behavioral Changes ###

Notifications should be created with the given properties.

~~**However:** The color `Resources` lookup doesn't seem to work. Not sure what I'm doing wrong? Or is using a resource the wrong approach?~~ No idea what I was seeing last night, but it's working now. 🤷‍♂ 

### Testing Procedure ###

Verified in my app.

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard