### PR TITLE
[Android] Fix INotificationDelegate Not Registered

### DIFF
--- a/src/Shiny.Notifications/Platforms/Uwp/NotificationBackgroundTaskProcessor.cs
+++ b/src/Shiny.Notifications/Platforms/Uwp/NotificationBackgroundTaskProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.Extensions.DependencyInjection;
 using Shiny.Infrastructure;
 using Shiny.Logging;
 using Windows.ApplicationModel.Background;
@@ -10,13 +11,13 @@ namespace Shiny.Notifications
     public class NotificationBackgroundTaskProcessor : IBackgroundTaskProcessor
     {
         readonly ISerializer serializer;
-        readonly INotificationDelegate ndelegate;
+        readonly IServiceProvider serviceProvider;
 
 
-        public NotificationBackgroundTaskProcessor(ISerializer serializer, INotificationDelegate ndelegate)
+        public NotificationBackgroundTaskProcessor(ISerializer serializer, IServiceProvider serviceProvider)
         {
             this.serializer = serializer;
-            this.ndelegate = ndelegate;
+            this.serviceProvider = serviceProvider;
         }
 
 
@@ -58,7 +59,11 @@ namespace Shiny.Notifications
                 //{
                 //    //native.Notification.Visual.Bindings.
                 //}
-                //this.ndelegate.OnEntry()
+                //var ndelegate = this.serviceProvider.GetService<INotificationDelegate>();
+                //if (ndelegate != null)
+                //{
+                //    ndelegate.OnEntry()
+                //}
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
### Description of Change ###

Resolve `INotificationDelegate` manually and check for `null`, since it might not be registered. Similar to f39ea7ff5eff524a73cb9bb3667624e7f89aa276.

Implementation mirrors:
https://github.com/shinyorg/shiny/blob/af46ecfee901d8d5edc50ee3cee2a739f0ecef99/src/Shiny.Notifications/Platforms/Android/NotificationBroadcastReceiver.cs#L26-L28

Or it could be refactored to use `SafeResolveAndExecute()`:
https://github.com/shinyorg/shiny/blob/692df1d45d40bd170843dff89abf053640d2766a/src/Shiny.Notifications/Platforms/Android/NotificationManager.cs#L166

And for completeness, iOS uses `Lazy`:
https://github.com/shinyorg/shiny/blob/f39ea7ff5eff524a73cb9bb3667624e7f89aa276/src/Shiny.Notifications/Platforms/iOS/ShinyNotificationDelegate.cs#L10 https://github.com/shinyorg/shiny/blob/f39ea7ff5eff524a73cb9bb3667624e7f89aa276/src/Shiny.Notifications/Platforms/iOS/ShinyNotificationDelegate.cs#L15-L16

### Issues Resolved ### 

- fixes #199

### API Changes ###

 None

### Platforms Affected ### 

- Android
- UWP

### Behavioral Changes ###

None

### Testing Procedure ###

Didn't test, but seems straightforward?

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard