### PR TITLE
Correctly obtaining transfer uri from cursor

### DIFF
--- a/src/Shiny.Net.Http/Platforms/Android/PlatformExtensions.cs
+++ b/src/Shiny.Net.Http/Platforms/Android/PlatformExtensions.cs
@@ -72,7 +72,7 @@ namespace Shiny.Net.Http
             var id = cursor.GetLong(Native.ColumnId).ToString();
             var fileSize = cursor.GetLong(Native.ColumnTotalSizeBytes);
             var bytesTransferred = cursor.GetLong(Native.ColumnBytesDownloadedSoFar);
-            var uri = cursor.GetString(Native.ColumnLocalUri);
+            var uri = cursor.GetString(Native.ColumnUri);
             var localPath = cursor.GetString(Native.ColumnDescription); // temp piggybacking
             var nstatus = (DownloadStatus)cursor.GetInt(Native.ColumnStatus);
 


### PR DESCRIPTION
### Description of Change ###

Changed the column from which the remote uri is obtained when a HttpTransfer is constructed from ICursor.

### Issues Resolved ### 
- fixes #232

### API Changes ###
 None

### Platforms Affected ### 
- Android

### Behavioral Changes ###
None

### Testing Procedure ###
Download files that should return an error.

### PR Checklist ###
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard