### PR TITLE
Fix outdated startup guide for UWP

### DIFF
--- a/input/docs/gettingstarted.md
+++ b/input/docs/gettingstarted.md
@@ -152,13 +152,13 @@ public override bool FinishedLaunching(UIApplication app, NSDictionary options)
 1. Add the following to your App.xaml.cs constructor
 
 ```csharp
-Shiny.UwpShinyHost.Init(new YourStartup());
+this.ShinyInit(new YourStartup());
 ```
 
 2. Add the following to your Package.appxmanifest under the <Application><Extensions> node
 
 ```xml
-<Extension Category="windows.backgroundTasks" EntryPoint="Shiny.Support.Uwp.ShinyBackgroundTask">
+<Extension Category="windows.backgroundTasks" EntryPoint="Shiny.ShinyBackgroundTask">
     <BackgroundTasks>
         <Task Type="general"/>
         <Task Type="systemEvent"/>


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. -->

Updated the startup guide for UWP.
When you use `EntryPoint="Shiny.Support.Uwp.ShinyBackgroundTask"`, then there will be a Validation error in the manifest.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

None

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- UWP

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard