### PR TITLE
LocationManager IsLocationEnabled is only available on Android api 28…

### DIFF
--- a/src/Shiny.Locations/Platforms/Android/PlatformExtensions.cs
+++ b/src/Shiny.Locations/Platforms/Android/PlatformExtensions.cs
@@ -17,8 +17,20 @@ namespace Shiny.Locations
         {
             //var hasGps = locationManager.IsProviderEnabled(LocationManager.GpsProvider);
             var lm = context.GetSystemService<LocationManager>(Context.LocationService);
-            if (!lm.IsLocationEnabled)
-                return AccessState.Disabled;
+            
+            if (Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.P)
+            {
+                if (!lm.IsLocationEnabled)
+                    return AccessState.Disabled;
+            }
+            else
+            {
+                if (!lm.IsProviderEnabled(LocationManager.NetworkProvider) &&
+                    !lm.IsProviderEnabled(LocationManager.GpsProvider))
+                {
+                    return AccessState.Disabled;
+                }
+            }
 
             if (gpsRequired && !lm.IsProviderEnabled(LocationManager.GpsProvider))
                 return AccessState.Disabled;

--- a/src/Shiny.Notifications/AndroidOptions.cs
+++ b/src/Shiny.Notifications/AndroidOptions.cs
@@ -7,7 +7,7 @@ namespace Shiny.Notifications
     {
         public static string? DefaultChannelId { get; set; } = "shinynotificationchannelid";
         public static string? DefaultChannel { get; set; } = "shinynotificationchannel";
-        public static string? DefaultSmallIconResourceName { get; set; } = "notification";
+        public static string? DefaultSmallIconResourceName { get; set; }
         public static string? DefaultLargeIconResourceName { get; set; }
         public static string? DefaultColorResourceName { get; set; }
         public static string? DefaultChannelDescription { get; set; }

--- a/src/Shiny.Notifications/Platforms/Android/NotificationManager.cs
+++ b/src/Shiny.Notifications/Platforms/Android/NotificationManager.cs
@@ -298,8 +298,13 @@ namespace Shiny.Notifications
         protected virtual int GetSmallIconResource(Notification notification)
         {
             if (notification.Android.SmallIconResourceName.IsEmpty())
-                return this.context.AppContext.ApplicationInfo.Icon;
+            {
+                var id = this.context.GetResourceIdByName("notification");
+                if (id > 0)
+                    return id;
 
+                return this.context.AppContext.ApplicationInfo.Icon;
+            }
             var smallIconResourceId = this.context.GetResourceIdByName(notification.Android.SmallIconResourceName);
             if (smallIconResourceId <= 0)
                 throw new ArgumentException($"Icon ResourceId for {notification.Android.SmallIconResourceName} not found");


### PR DESCRIPTION
… and up.

### Description of Change ###
Geofencing on Android is crashing when run on android device with OS 8.1 and lower since IsLocationEnabled is only available in api 28.

### Issues Resolved ### 
- Added code to check the api level before making the call to IsLocationEnabled

### API Changes ###
Android Geofencing

### Platforms Affected ### 
- Android

### Testing Procedure ###
Just start the Geofencing session on a device running Android 8.1 and lower 
