### PR TITLE
Update PlatformExtensions.cs

### DIFF
--- a/src/Shiny.Core/Platforms/Apple/PlatformExtensions.cs
+++ b/src/Shiny.Core/Platforms/Apple/PlatformExtensions.cs
@@ -33,11 +33,7 @@ namespace Shiny
 
         public static NSDictionary ToNsDictionary(this IDictionary<string, string> dict)
         {
-            var ns = new NSDictionary();
-            foreach (var pair in dict)
-                ns.SetValueForKey(new NSString(pair.Value), new NSString(pair.Key));
-
-            return ns;
+            return NSDictionary.FromObjectsAndKeys(dict.Values.ToArray(), dict.Keys.ToArray());
         }
 
 


### PR DESCRIPTION
The ToNsDictionary method has a bug. NSDictionary objects are immutable, and this method causes a crash at SetValueForKey (the error is this class is not key value coding-compliant for the key)

Credit to a StackOverflow answer for an elegant alternative https://stackoverflow.com/questions/36027542/xamarin-ios-convert-dictionary-to-nsdictionary

### Description of Change ###

The NSDictionary is immutable so using an alternative means to create an NSDictionary and populate it with keys and values from an IDictionary. 

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- All

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

I didn't test this fix, but I did test setting a payload in a notification and hit the error described at the top. This issue was actually fixed before (see https://github.com/shinyorg/shiny/issues/15) so I'm sure the use of NSDictionary is the culprit here.

### PR Checklist ###

- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard