### PR TITLE
iOS 13 uses of CLBeaconRegion for ranging is deprecated.

### DIFF
--- a/src/Shiny.Beacons/Platforms/iOS/BeaconManager.cs
+++ b/src/Shiny.Beacons/Platforms/iOS/BeaconManager.cs
@@ -31,7 +31,7 @@ namespace Shiny.Beacons
 
         public override IObservable<Beacon> WhenBeaconRanged(BeaconRegion region)
         {
-            var native = region.ToNative();
+            var native = region.ToNativeCLBeaconIdentityConstraint();
             this.manager.StartRangingBeacons(native);
 
             return this.gdelegate

--- a/src/Shiny.Beacons/Platforms/iOS/PlatformExtensions.cs
+++ b/src/Shiny.Beacons/Platforms/iOS/PlatformExtensions.cs
@@ -30,6 +30,26 @@ namespace Shiny.Beacons
             return native;
         }
 
+        public static CLBeaconIdentityConstraint ToNativeCLBeaconIdentityConstraint(this BeaconRegion region)
+        {
+            if (region.Uuid == null)
+                throw new ArgumentException("You must pass a UUID for the Beacon Region");
+
+            var uuid = region.Uuid.ToNSUuid();
+            CLBeaconIdentityConstraint native;
+
+            if (region.Major > 0 && region.Minor > 0)
+                native = new CLBeaconIdentityConstraint(uuid, region.Major.Value, region.Minor.Value);
+
+            else if (region.Major > 0)
+                native = new CLBeaconIdentityConstraint(uuid, region.Major.Value);
+
+            else
+                native = new CLBeaconIdentityConstraint(uuid);
+
+            return native;
+        }
+
 
         public static Proximity FromNative(this CLProximity proximity)
         {


### PR DESCRIPTION
### Description of Change ###

Starting iOS 13 uses of CLBeaconRegion for ranging is deprecated. Changed to the new api using CLBeaconIdentityConstraint
https://developer.apple.com/documentation/corelocation/cllocationmanager/3240607-startrangingbeacons

### Issues Resolved ### 
NA

### API Changes ###
 None

### Platforms Affected ### 
- iOS

### Behavioral Changes ###
None

### Testing Procedure ###
I am not sure how to test it yet.

### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard