### PR TITLE
Getting default value for not yet cached item from SQLite

### DIFF
--- a/src/Shiny.Integrations.Sqlite/SqliteCache.cs
+++ b/src/Shiny.Integrations.Sqlite/SqliteCache.cs
@@ -29,7 +29,7 @@ namespace Shiny.Integrations.Sqlite
 
         public override async Task<T> Get<T>(string key)
         {
-            var item = await this.conn.GetAsync<CacheStore>(key);
+            var item = await this.conn.FindAsync<CacheStore>(key);
             if (item == null)
                 return default;
 


### PR DESCRIPTION
### Description of Change ###

Now GetAsync call from SqliteCache returns default value if object not found

### Issues Resolved ### 
#326 

### API Changes ###
Changing GetAsync to FindAsync in SqliteCache

### Platforms Affected ### 

- All

### Behavioral Changes ###
Works as expected

### Testing Procedure ###
Get an object from sqlite cache wich was not yet set

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard