### PR TITLE
#330 fix: No more exception getting item from repository cache

### DIFF
--- a/src/Shiny.Core/Caching/ServiceCollectionExtensions.cs
+++ b/src/Shiny.Core/Caching/ServiceCollectionExtensions.cs
@@ -40,7 +40,8 @@ namespace Shiny
             => services.AddSingleton<ICache>(sp =>
             {
                 var repository = sp.GetRequiredService<IRepository>();
-                return new RepositoryCache(repository, defaultLifespan, cleanUpTimer);
+                var serializer = sp.GetRequiredService<ISerializer>();
+                return new RepositoryCache(repository, serializer, defaultLifespan, cleanUpTimer);
             });
     }
 }


### PR DESCRIPTION
### Description of Change ###
We check if object is of T type or deserialize it before returning the value from RepositoryCache.Get< T >(key)

### Issues Resolved ### 
fixes #330 

### API Changes ###
RepositoryCache.Get< T >(key) and its service collection registration

### Platforms Affected ### 

- All

### Behavioral Changes ###
Works like expected

### Testing Procedure ###
Described in the issue

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard