### PR TITLE
fix android docs

### DIFF
--- a/src/Shiny.Notifications/readme.txt
+++ b/src/Shiny.Notifications/readme.txt
@@ -59,7 +59,7 @@ public override void OnCreate(Bundle savedInstanceState)
     base.OnCreate(savedInstanceState);
 }
 
-public override void OnNewIntent(Intent intent)
+protected override void OnNewIntent(Intent intent)
 {
     this.ShinyOnNewIntent(intent);
     base.OnNewIntent(intent);
@@ -67,7 +67,7 @@ public override void OnNewIntent(Intent intent)
 
 public override void OnRequestPermissionsResult(int requestCode, string[] permissions, Permission[] grantResults)
 {
-    this.Shiny.OnRequestPermissionsResult(requestCode, permissions, grantResults);
+    this.ShinyRequestPermissionsResult(requestCode, permissions, grantResults);
     base.OnRequestPermissionsResult(requestCode, permissions, grantResults);
 }
 


### PR DESCRIPTION
### Description of Change ###

fixes ReadMe for Shiny.Notifications. The ReadMe currently has some old/invalid references for how to setup Android.

### Issues Resolved ### 

n/a

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral Changes ###

None

### Testing Procedure ###

n/a

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard