### PR TITLE
Bugfix: Crash when BLE device does not send any ManufacturerSpecificData

### DIFF
--- a/src/Shiny.BluetoothLE/Platforms/Android/AdvertisementData.cs
+++ b/src/Shiny.BluetoothLE/Platforms/Android/AdvertisementData.cs
@@ -15,6 +15,9 @@ namespace Shiny.BluetoothLE
 
             this.manufacturerData = new Lazy<ManufacturerData?>(() =>
             {
+                if (this.result.ScanRecord.ManufacturerSpecificData == null || this.result.ScanRecord.ManufacturerSpecificData.Size() == 0)
+                    return null;
+
                 var manufacturerId = (ushort)this.result.ScanRecord.ManufacturerSpecificData.KeyAt(0);
                 if (manufacturerId == 0)
                     return null;


### PR DESCRIPTION
### Description of Change ###

Bugfix: Crash when a BLE device does not send any ManufacturerSpecificData
I have check the documentation and the API getManufacturerSpecificData must return an array.
My reproduction case was with an empty array. Looking at some other usages of the api on github, I have often see code checking also for null and I have also added a check on it. The method can return null if given a manufacturerId, so I suspect it could also be the case when having no argument.

Official doc : https://developer.android.com/reference/android/bluetooth/le/ScanRecord#getManufacturerSpecificData()
Another app checking for null and empty : https://github.com/angelkjos/BLEBeaconScanner/blob/1ef27ba38f9006f97d8eddfc4db39788880fb4e3/app/src/main/java/com/angelkjoseski/blebeacon/IBeaconResult.java#L28

### Issues Resolved ### 
A native exception was raised crashing the app.

### API Changes ###
None
 
### Platforms Affected ### 
- Android


### Behavioral Changes ###
None

### Testing Procedure ###
Difficult to test, but you must find a bluetooth device that does not send any ManufacturerSpecificData. Look like I have one at home along the tens I have.

### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard