### PR TITLE
Add iOSSharedManagerWithinProcess Config Option

### DIFF
--- a/src/Shiny.BluetoothLE.Abstractions/BleConfiguration.cs
+++ b/src/Shiny.BluetoothLE.Abstractions/BleConfiguration.cs
@@ -43,5 +43,10 @@ namespace Shiny.BluetoothLE
         /// CBCentralInitOptions restoration key for background restoration
         /// </summary>
         public string iOSRestoreIdentifier { get; set; } = "shinyble";
+
+        /// <summary>
+        /// Make sure that the CentralContext shares the same instance of CBCentralManager while in the same process
+        /// </summary>
+        public bool iOSSharedManagerWithinProcess { get; set; } = false;
     }
 }

--- a/src/Shiny.BluetoothLE/Platforms/ios+tvos/Internals/CentralContext.cs
+++ b/src/Shiny.BluetoothLE/Platforms/ios+tvos/Internals/CentralContext.cs
@@ -11,9 +11,9 @@ namespace Shiny.BluetoothLE.Internals
 {
     public class CentralContext : CBCentralManagerDelegate
     {
+        static CBCentralManager staticManager;
         readonly ConcurrentDictionary<string, IPeripheral> peripherals = new ConcurrentDictionary<string, IPeripheral>();
         readonly IServiceProvider services;
-
 
         public CentralContext(IServiceProvider services, BleConfiguration config)
         {
@@ -33,7 +33,21 @@ namespace Shiny.BluetoothLE.Internals
             if (!config.iOSRestoreIdentifier.IsEmpty())
                 opts.RestoreIdentifier = config.iOSRestoreIdentifier;
 
-            this.Manager = new CBCentralManager(this, null, opts);
+            if (config.iOSSharedManagerWithinProcess)
+            {
+                if (staticManager == null)
+                {
+                    staticManager = new CBCentralManager(this, null, opts);
+                }
+                else
+                {
+                    staticManager.Delegate = this;
+                }
+                this.Manager = staticManager;
+            } else
+            {
+                this.Manager = new CBCentralManager(this, null, opts);
+            }
         }
 
 


### PR DESCRIPTION

### Description of Change ###

Implemented the ability to signal to the CentralContext to use a static CBCentralManager, for sharing the same instance within a process.

This was necessary for a use-case with using Shiny within an intents app extension for iOS. Because the app extension process is long lived between intent triggers, it was undesirable (and unworkable) to have it make a new instance of the `CBCentralManager` each time an intent was triggered. Having a new instance would case the delegates not be called when the state of the adapter changed. The solution was to make the `CBCentralManager` static to the `CentralContext` class, so if previously instantiated that instance would be used.

### Issues Resolved ### 

None recorded

### API Changes ###

None

### Platforms Affected ### 

- iOS

### Behavioral Changes ###

This is a completely optional feature, the config option is false by default, and behavior remains the same then.

### Testing Procedure ###



### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard (I believe so)
