### PR TITLE
Modified iBeacon detection for other manufacturers that use the optional mfg reserved byte on ManufacturerData.

### DIFF
--- a/src/Shiny.Beacons.Abstractions/Extensions.cs
+++ b/src/Shiny.Beacons.Abstractions/Extensions.cs
@@ -100,16 +100,14 @@ namespace Shiny.Beacons
         }
 
 
-        public static bool IsBeaconPacket(this byte[] data, bool skipManufacturerByte = true)
+        public static bool IsBeaconPacket(this byte[] data)
         {
-            if (data == null)
+            // room for iBeacon type code (2) + proximity uuid (16) + major (2) + minor (2) + measured power (1) + optional mfg reserved (1)
+            if (data.Length < 23 && data.Length > 24)
                 return false;
 
-            if (data.Length != 23)
-                return false;
-
-            // apple manufacturerID - https://www.bluetooth.com/specifications/assigned-numbers/company-Identifiers
-            if (!skipManufacturerByte && data[0] != 76)
+            // iBeacon type code
+            if (data[0] != 0x02 || data[1] != 0x15)
                 return false;
 
             return true;

--- a/src/Shiny.Beacons/Platforms/android+uwp/BleManagerExtensions.cs
+++ b/src/Shiny.Beacons/Platforms/android+uwp/BleManagerExtensions.cs
@@ -23,10 +23,10 @@ namespace Shiny.Beacons
         {
             var md = result.AdvertisementData?.ManufacturerData;
 
-            if (md == null || md.Data == null || md.Data.Length != 23)
+            if (md == null || md.Data == null)
                 return false;
 
-            if (md.CompanyId != 76)
+            if (md.CompanyId != 76) // only Apple standard iBeacons
                 return false;
 
             return md.Data.IsBeaconPacket();

--- a/tests/Shiny.Beacons.Tests/BeaconParserTests.cs
+++ b/tests/Shiny.Beacons.Tests/BeaconParserTests.cs
@@ -8,12 +8,19 @@ namespace Shiny.Tests.Beacons
 {
     public class BeaconParserTests
     {
-        [Theory(Skip = "TODO")]
+        [Theory()]
         [InlineData(
             "02-15-B9-40-7F-30-F5-F8-46-6E-AF-F9-25-55-6B-57-FE-6D-39-B0-57-CA-BE",
             "B9407F30-F5F8-466E-AFF9-25556B57FE6D",
+            14768,
+            22474,
+            Proximity.Immediate
+        )]
+        [InlineData(
+            "02-15-A7-AE-2E-B7-1F-00-41-68-B9-9B-A7-49-BA-C1-CA-64-00-01-00-40-C5-58",
+            "A7AE2EB7-1F00-4168-B99B-A749BAC1CA64",
             1,
-            1,
+            64,
             Proximity.Immediate
         )]
         public void ParseBeaconPacketSuccess(string hexData, string beaconIdentifier, ushort major, ushort minor, Proximity prox)


### PR DESCRIPTION
### Description of Change ###

Modified IsBeaconPacket function that supports ManufacturerData byte array of 24 bytes instead of 23. Related with the use of an optional 'mfg reserved' byte for manufacturer's use.

### Issues Resolved ### 

- fixes #439

### API Changes ###
 
Removed skipManufacturerByte parameter in IsBeaconPacket function. Not used because the ManufacturerData thasn't have any information about a manufacturer byte.

### Platforms Affected ### 

- All

### Behavioral Changes ###

Detection of more iBeacons.

### Testing Procedure ###

Getting closer to a ProximiPro iBeacon (and maybe others, Estimote?).

### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard