### PR TITLE
Fix custom sounds in Shiny.Notification on Android, see issue #461

### DIFF
--- a/src/Shiny.Notifications/Platforms/Android/PlatformExtensions.cs
+++ b/src/Shiny.Notifications/Platforms/Android/PlatformExtensions.cs
@@ -40,5 +40,15 @@ namespace Shiny
                 "drawable",
                 context.AppContext.PackageName
             );
+
+        // Expects raw resource name like "notify_sound" or "raw/notify_sound"
+        internal static int GetRawResourceIdByName(this AndroidContext context, string rawName) => context
+            .AppContext
+            .Resources
+            .GetIdentifier(
+                rawName,
+                "raw",
+                context.AppContext.PackageName
+            );
     }
 }


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. -->

Two changes to Android NotificationManager in Shiny.Notification:
- Generate and use custom sound URI of the form *android.resource://<PKG_NAME>/raw/<RES_NAME>* (e.g. *android.resource://com.shiny.sample/raw/notification*) that allows Android to access the Apps' sound resource (see issue description).
- Call SetSound() with custom sound **before** notification channel is created
    NOTE: currently this also sets the vibration mode but I think thats OK

Note that custom sounds on Android 8 and above are only set properly
when the notification channel is created. Changing the sound later
in the Notification will have no effect until the App is re-installed (uninstalled and the installed again).
There might be other workaround too which I don't know of.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #461 

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral Changes ###
None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

* Tested manually on Android 5.1, 6, 9 and 11
* Can be tested with shinysamples app (need to include notification.mp3 resource though)

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard