### PR TITLE
Fix for BlobWrite*

### DIFF
--- a/src/Shiny.BluetoothLE.Abstractions/Extensions_Characteristics.cs
+++ b/src/Shiny.BluetoothLE.Abstractions/Extensions_Characteristics.cs
@@ -21,6 +21,7 @@ namespace Shiny.BluetoothLE
             var read = stream.Read(buffer, 0, buffer.Length);
             var pos = read;
             var len = Convert.ToInt32(stream.Length);
+            var remaining = 0;
 
             while (!ct.IsCancellationRequested && read > 0)
             {
@@ -36,6 +37,13 @@ namespace Shiny.BluetoothLE
                 //}
                 var seg = new BleWriteSegment(buffer, pos, len);
                 ob.OnNext(seg);
+
+                remaining = len - pos;
+                if (remaining > 0 && remaining < mtu)
+                {
+                    // readjust buffer -- we don't want to send extra garbage 
+                    buffer = new byte[remaining];
+                }
 
                 read = stream.Read(buffer, 0, buffer.Length);
                 pos += read;

--- a/src/Shiny.BluetoothLE.Abstractions/Feature_Transactions.cs
+++ b/src/Shiny.BluetoothLE.Abstractions/Feature_Transactions.cs
@@ -39,6 +39,7 @@ namespace Shiny.BluetoothLE
                 var read = stream.Read(buffer, 0, buffer.Length);
                 var pos = read;
                 var len = Convert.ToInt32(stream.Length);
+                var remaining = 0;
 
                 while (!ct.IsCancellationRequested && read > 0)
                 {
@@ -54,6 +55,13 @@ namespace Shiny.BluetoothLE
                     //}
                     var seg = new BleWriteSegment(buffer, pos, len);
                     ob.OnNext(seg);
+
+                    remaining = len - pos;
+                    if (remaining > 0 && remaining < mtu)
+                    {
+                        // readjust buffer -- we don't want to send extra garbage 
+                        buffer = new byte[remaining];
+                    }
 
                     read = stream.Read(buffer, 0, buffer.Length);
                     pos += read;


### PR DESCRIPTION
### Description of Change ###

Fix for BlobWrite when getting near end of buffer to adjust size, otherwise garbage is transmitted after the users data.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- All

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->
Write data larger then MTU size (e.g. when MTU is 20 bytes, write 63 bytes).
Tested on Android

### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard