### PR TITLE
#511 - Catching Exception "Quota exceeded" when calling `builder.Regi…

### DIFF
--- a/src/Shiny.Core/Jobs/Platforms/Uwp/JobManager.cs
+++ b/src/Shiny.Core/Jobs/Platforms/Uwp/JobManager.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.Background;
 using Shiny.Infrastructure;
+using Shiny.Logging;
 
 
 namespace Shiny.Jobs
@@ -78,7 +79,16 @@ namespace Shiny.Jobs
 
                 builder.AddCondition(new SystemCondition(type));
             }
-            builder.Register();
+
+            try
+            {
+                builder.Register();
+            }
+            catch (Exception x)
+            {
+                Log.Write("ScheduleNative", $"Failed to register job '{builder.Name}'");
+                Log.Write(x);
+            }
         }
 
 


### PR DESCRIPTION
…ster()` to avoid UWP app crashing at startup

### Description of Change ###

<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #511 

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- UWP

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard