### PR TITLE
Generator Fixes

### DIFF
--- a/src/Shiny.Generators/AndroidActivitySourceGenerator.cs
+++ b/src/Shiny.Generators/AndroidActivitySourceGenerator.cs
@@ -94,8 +94,8 @@ namespace Shiny.Generators
             }
             else
             {
-                builder.AppendFormatInvariant("partial void OnBeforeCreate(Bundle savedInstanceState);");
-                builder.AppendFormatInvariant("partial void OnAfterCreate(Bundle savedInstanceState);");
+                builder.AppendLineInvariant("partial void OnBeforeCreate(Bundle savedInstanceState);");
+                builder.AppendLineInvariant("partial void OnAfterCreate(Bundle savedInstanceState);");
                 using (builder.BlockInvariant("protected override void OnCreate(Bundle savedInstanceState)"))
                 {
                     builder.AppendLineInvariant("this.ShinyOnCreate();");
@@ -103,7 +103,7 @@ namespace Shiny.Generators
 
                     if (String.IsNullOrWhiteSpace(this.values.XamarinFormsAppTypeName))
                     {
-                        builder.AppendFormatInvariant("base.OnCreate(savedInstanceState);");
+                        builder.AppendLineInvariant("base.OnCreate(savedInstanceState);");
                     }
                     else
                     {
@@ -116,6 +116,10 @@ namespace Shiny.Generators
                             builder.AppendLineInvariant("base.OnCreate(savedInstanceState);");
                             builder.AppendLineInvariant("global::Xamarin.Forms.Forms.Init(this, savedInstanceState);");
                             builder.AppendLineInvariant($"this.LoadApplication(new {this.values.XamarinFormsAppTypeName}());");
+                        }
+                        else
+                        {
+                            builder.AppendLineInvariant("base.OnCreate(savedInstanceState);");
                         }
                     }
                     this.TryAppendOnCreateThirdParty(activity, builder);

--- a/src/Shiny.Generators/iOSAppDelegateSourceGenerator.cs
+++ b/src/Shiny.Generators/iOSAppDelegateSourceGenerator.cs
@@ -196,6 +196,9 @@ public override bool OpenUrl(UIApplication app, NSUrl url, NSDictionary options)
             {
                 // do XF stuff
                 builder.AppendLineInvariant("global::Xamarin.Forms.Forms.Init();");
+                if (this.Context.Compilation.GetTypeByMetadataName("Xamarin.Forms.FormsMaterial") != null)
+                    builder.AppendLineInvariant("global::Xamarin.Forms.FormsMaterial.Init();");
+
                 builder.AppendLineInvariant($"this.LoadApplication(new {this.ShinyConfig.XamarinFormsAppTypeName}());");
             }
 


### PR DESCRIPTION
### Description of Change ###

Fixes Generator output. This fixes a few issues actually...

- Multiple lines on a single line making it harder to read
- Adds call to base.OnCreate
- Adds init on iOS for Xamarin.Forms.FormsMaterial

### Issues Resolved ### 

- fixes #564

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS
- Android

### Behavioral Changes ###

None

### Testing Procedure ###

On Android add a Splash Activity like you see in the Prism.Forms samples / template. If the app launches when using the generators then it is generating correctly.

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard