### PR TITLE
fix variable name

### DIFF
--- a/src/Shiny/targets/shiny.targets
+++ b/src/Shiny/targets/shiny.targets
@@ -4,7 +4,7 @@
     </PropertyGroup>
 
     <Target Name="_ShinyMSBuildVersionCheck"
-            Condition=" '$([System.Version]::Parse($(_RefitMSBuildMinVersion)).CompareTo($([System.Version]::Parse($(MSBuildVersion)))))' &gt; '0' "
+            Condition=" '$([System.Version]::Parse($(_MSBuildMinVersion)).CompareTo($([System.Version]::Parse($(MSBuildVersion)))))' &gt; '0' "
             BeforeTargets="ResolveAssemblyReferences;Build;Rebuild" >
         <Error Text="Projects using Shiny cannot build using MSBuild '$(MSBuildVersion)'. MSBuild '$(_MSBuildMinVersion)' or later is required." />
     </Target>


### PR DESCRIPTION
### Description of Change ###

Fixes invalid parameter name... the parameter _RefitMSBuildMinVersion does not exist and therefore the Target encounters a parsing error breaking the build.

### Issues Resolved ### 

- hot fix

### API Changes ###
 
 None

### Platforms Affected ### 

- All

### Behavioral Changes ###

None

### Testing Procedure ###

Build an app

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard