### PR TITLE
Use Project Root Namespace

### DIFF
--- a/src/Shiny.Generators/ShinyApplicationSourceGenerator.cs
+++ b/src/Shiny.Generators/ShinyApplicationSourceGenerator.cs
@@ -16,11 +16,13 @@ namespace Shiny.Generators
         protected ShinyApplicationSourceGenerator(string osApplicationTypeName) => this.osApplicationTypeName = osApplicationTypeName;
         protected GeneratorExecutionContext Context { get; private set; }
         public ShinyApplicationValues ShinyConfig { get; set; }
-
+        protected string RootNamespace { get; private set; }
 
         public virtual void Execute(GeneratorExecutionContext context)
         {
             context.TryDebug();
+
+            this.RootNamespace = context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.RootNamespace", out var rootNamespace) ? rootNamespace : context.Compilation.AssemblyName ?? "ShinyApp";
 
             this.Context = context;
             var shinyAppAttributeData = context.GetCurrentAssemblyAttribute(Constants.ShinyApplicationAttributeTypeName);
@@ -36,7 +38,7 @@ namespace Shiny.Generators
 
             if (String.IsNullOrWhiteSpace(this.ShinyConfig.ShinyStartupTypeName))
             {
-                this.GenerateStartup(this.Context.Compilation.AssemblyName);
+                this.GenerateStartup(RootNamespace);
                 this.ShinyConfig.ShinyStartupTypeName = GENERATED_STARTUP_TYPE_NAME;
             }
 

--- a/src/Shiny/targets/shiny.props
+++ b/src/Shiny/targets/shiny.props
@@ -1,8 +1,9 @@
 ﻿<Project>
-	<ItemGroup>
-		<CompilerVisibleProperty Include="OutputType" />
-		<CompilerVisibleProperty Include="TargetFrameworkIdentifier" />
-        <!--<AdditionalFiles Include="Info.plist" />
-        <AdditionalFiles Include="Entitlements.plist" />-->
-	</ItemGroup>
+  <ItemGroup>
+    <CompilerVisibleProperty Include="OutputType" />
+    <CompilerVisibleProperty Include="TargetFrameworkIdentifier" />
+    <CompilerVisibleProperty Include="RootNamespace" />
+    <!--<AdditionalFiles Include="Info.plist" />
+    <AdditionalFiles Include="Entitlements.plist" />-->
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
### Description of Change ###

Updates the ShinyApplicationSourceGenerator to pull the RootNamespace from the Build props.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- none

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- All

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Generates the Application using the RootNamespace property from the project system with fallback to the Assembly name if the RootNamespace property was null for some reason.

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard