### PR TITLE
#698 - Fixed issue where Bluetooth scan exceptions were not being passed to subscribers

### DIFF
--- a/src/Shiny.BluetoothLE/Managed/ManagedScan.cs
+++ b/src/Shiny.BluetoothLE/Managed/ManagedScan.cs
@@ -143,6 +143,9 @@ namespace Shiny.BluetoothLE.Managed
                             result.LastSeen = DateTimeOffset.UtcNow;
                             this.actionSubj.OnNext((action, result));
                         }
+                    }, e =>
+                    {
+                        this.actionSubj.OnError(e);
                     }
                 );
         }


### PR DESCRIPTION
Added onError action for ManagedScan.Start()