### PR TITLE
Fix property accessor check in ObjectStoreBinder

### DIFF
--- a/src/Shiny.Core/Stores/ObjectStoreBinder.cs
+++ b/src/Shiny.Core/Stores/ObjectStoreBinder.cs
@@ -113,13 +113,15 @@ namespace Shiny.Stores
         public static string GetBindingKey(Type type, string propertyName)
             => $"{type.Namespace}.{type.Name}.{propertyName}";
 
-
+        /// <summary>
+        /// Get all type properties with public get and set accessors
+        /// </summary>
         protected virtual IEnumerable<PropertyInfo> GetTypeProperties(Type type) => type
             .GetTypeInfo()
             .DeclaredProperties
             .Where(x =>
-                x.CanRead &&
-                x.CanWrite
+                (x.GetGetMethod() != null) &&
+                (x.GetSetMethod() != null)
             );
 
 

--- a/src/Shiny.Core/Stores/ObjectStoreBinder.cs
+++ b/src/Shiny.Core/Stores/ObjectStoreBinder.cs
@@ -78,7 +78,7 @@ namespace Shiny.Stores
                 // Skip if there are no properties to bind
                 if (props.Count == 0)
                 {
-                    this.logger.LogInformation($"Skip model bind (no public props): {npc.GetType().FullName} to store: {store.Alias}");
+                    this.logger?.LogInformation($"Skip model bind (no public props): {npc.GetType().FullName} to store: {store.Alias}");
                     return;
                 }
 
@@ -99,12 +99,12 @@ namespace Shiny.Stores
                     }
                 }
                 npc.PropertyChanged += this.OnPropertyChanged;
-                this.logger.LogInformation($"Successfully bound model: {npc.GetType().FullName} to store: {store.Alias}");
+                this.logger?.LogInformation($"Successfully bound model: {npc.GetType().FullName} to store: {store.Alias}");
                 this.bindings.Add(npc, store);
             }
             catch (Exception ex)
             {
-                this.logger.LogError(ex, $"Failed to bind model: {npc?.GetType().FullName ?? "Unknown"} to store: {store.Alias}");
+                this.logger?.LogError(ex, $"Failed to bind model: {npc?.GetType().FullName ?? "Unknown"} to store: {store.Alias}");
             }
         }
 

--- a/src/Shiny.Core/Stores/ObjectStoreBinder.cs
+++ b/src/Shiny.Core/Stores/ObjectStoreBinder.cs
@@ -73,7 +73,14 @@ namespace Shiny.Stores
             try
             {
                 var type = npc.GetType();
-                var props = this.GetTypeProperties(type);
+                var props = this.GetTypeProperties(type).ToList();
+
+                // Skip if there are no properties to bind
+                if (props.Count == 0)
+                {
+                    this.logger.LogInformation($"Skip model bind (no public props): {npc.GetType().FullName} to store: {store.Alias}");
+                    return;
+                }
 
                 foreach (var prop in props)
                 {

--- a/tests/Shiny.Tests.Shared/Core/Stores/StoreTests.ObjectBinder.cs
+++ b/tests/Shiny.Tests.Shared/Core/Stores/StoreTests.ObjectBinder.cs
@@ -74,6 +74,32 @@ namespace Shiny.Tests.Core.Stores
 
 
         [Trait("Category", "ObjectBinder")]
+        [Theory]
+        [MemberData(nameof(Data))]
+        public void Binding_ProtectedSetter(IKeyValueStore store)
+        {
+            var values = SetupBinder<TestBind>(store);
+            var key = ObjectStoreBinder.GetBindingKey(typeof(TestBind), nameof(TestBind.ProtectedSetterProperty));
+
+            values.BoundObject.SetProtectedProperty(Guid.NewGuid().ToString());
+            store.Contains(key).Should().BeFalse();
+        }
+
+
+        [Trait("Category", "ObjectBinder")]
+        [Theory]
+        [MemberData(nameof(Data))]
+        public void Binding_ProtectedGetter(IKeyValueStore store)
+        {
+            var values = SetupBinder<TestBind>(store);
+            var key = ObjectStoreBinder.GetBindingKey(typeof(TestBind), nameof(TestBind.ProtectedGetterProperty));
+
+            values.BoundObject.ProtectedGetterProperty = Guid.NewGuid().ToString();
+            store.Contains(key).Should().BeFalse();
+        }
+
+
+        [Trait("Category", "ObjectBinder")]
         [Fact]
         public void AttributeBinding()
         {

--- a/tests/Shiny.Tests.Shared/Core/Stores/TestBind.cs
+++ b/tests/Shiny.Tests.Shared/Core/Stores/TestBind.cs
@@ -29,5 +29,26 @@ namespace Shiny.Tests.Core.Stores
             get => this.intValue;
             set => this.Set(ref this.intValue, value);
         }
+
+
+        string? protectedGetterProperty;
+        public string? ProtectedGetterProperty
+        {
+            protected get => this.protectedGetterProperty;
+            set => this.Set(ref this.protectedGetterProperty, value);
+        }
+
+        
+        string? protectedSetterProperty;
+        public string? ProtectedSetterProperty
+        {
+            get => this.protectedSetterProperty;
+            protected set => this.Set(ref this.protectedSetterProperty, value);
+        }
+
+        public void SetProtectedProperty(string? value)
+        {
+            this.ProtectedSetterProperty = value;
+        }
     }
 }


### PR DESCRIPTION
For: https://github.com/shinyorg/shiny/issues/740
See: https://stackoverflow.com/a/10461575/2634818

Only returns properties where the getter and setter are publicly accessible. Doesn't bind PropertyChanged on objects without any available properties.

Would be great to see this patch merged to master for v2.3?