### PR TITLE
Fix iOS setup doc

### DIFF
--- a/docs/Input/setup/ios.md
+++ b/docs/Input/setup/ios.md
@@ -36,9 +36,11 @@ public partial class AppDelegate
     {
         this.OnPreFinishedLaunching(app, options);
         this.ShinyFinishedLaunching(new Samples.SampleStartup());
-        this.LoadApplication(new Samples.App());        
+
         global::Xamarin.Forms.Forms.Init();
-        
+
+        this.LoadApplication(new Samples.App());
+
         global::XF.Material.iOS.Material.Init();
         this.OnPostFinishedLaunching(app, options);
         return base.FinishedLaunching(app, options);


### PR DESCRIPTION
The previous setup throws an exception on a new basic Xamarin.Forms project:

Xamarin.Forms.Device:
<img width="1114" alt="Screen Shot 2021-10-11 at 6 21 04 PM" src="https://user-images.githubusercontent.com/766193/136816108-53c2fba8-45dd-4b3d-a4e1-e3ac70b98bee.png">

Versions:
- Xamarin.Forms 5.0.0.2125
- Shiny 2.2.0.2829