### PR TITLE
Register implemented IGeofenceDelegate on iOS if using a custom delegate.

### DIFF
--- a/src/Shiny.Locations/Platforms/Shared/ServiceCollectionExtensions.cs
+++ b/src/Shiny.Locations/Platforms/Shared/ServiceCollectionExtensions.cs
@@ -53,6 +53,7 @@ namespace Shiny
             services.TryAddSingleton<IGeofenceManager, GeofenceManagerImpl>();
             return true;
 #elif __IOS__
+            services.TryAddSingleton(typeof(IGeofenceDelegate), delegateType);
             services.TryAddSingleton<IGeofenceManager, GeofenceManagerImpl>();
             return true;
 #else


### PR DESCRIPTION
### Description of Change ###

Register implemented IGeofenceDelegate on iOS if using a custom delegate.

### Issues Resolved ### 

If trying to resolve an instance of a custom IGeofenceDelegate on iOS through dependency injection, or ShinyHost, a null reference exception will be thrown because the delegate isn't registered as the implemented interface.
Resolving by class works, however that makes it untestable.

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral Changes ###

None

### Testing Procedure ###

Create a custom delegate for geofencing, and implement IGeofenceDelegate.
Next - on iOS - try to resolve this custom delegate from the container through Dependency Injection, or via static ShinyHost.

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Sent to DEV branch