### PR TITLE
Bug fix: App crashes when file doesn't start with file://

### DIFF
--- a/src/Shiny.Net.Http/Platforms/iOS/HttpTransferManager.cs
+++ b/src/Shiny.Net.Http/Platforms/iOS/HttpTransferManager.cs
@@ -62,7 +62,7 @@ namespace Shiny.Net.Http
 
         protected override Task<HttpTransfer> CreateUpload(HttpTransferRequest request)
         {
-            var fileUrl = new NSUrl(request.LocalFile.FullName);
+            var fileUrl = NSUrl.CreateFileUrl(request.LocalFile.FullName, null);
             var task = this.Session.CreateUploadTask(request.ToNative(), fileUrl);
             var taskId = TaskIdentifier.Create(request.LocalFile);
             task.TaskDescription = taskId.ToString();


### PR DESCRIPTION
### Description of Change ###

The upload task needs a valid file url starting with file:// or else the app will crash.

Before the url looks like this:
`/Users/name/Library/Devices/0306F371-E608-42B1-8C1F-D9315835E5C8/Documents/test.png`
After change:
`file:///Users/name/Library/Devices/0306F371-E608-42B1-8C1F-D9315835E5C8/Documents/test.png`

### Issues Resolved ### 

- fixes #782

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
- [X] Sent to DEV branch