### PR TITLE
Set content-type of iOS file upload

### DIFF
--- a/src/Shiny.Net.Http/Platforms/iOS/HttpTransferManager.cs
+++ b/src/Shiny.Net.Http/Platforms/iOS/HttpTransferManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -71,9 +71,13 @@ namespace Shiny.Net.Http
             if (request.HttpMethod != System.Net.Http.HttpMethod.Post && request.HttpMethod != System.Net.Http.HttpMethod.Put)
                 throw new ArgumentException($"Invalid Upload HTTP Verb {request.HttpMethod} - only PUT or POST are valid");
 
-            var native = request.ToNative();
             var boundary = Guid.NewGuid().ToString();
+	            
+            var native = request.ToNative();
+            native["Content-Type"] = $"multipart/form-data; boundary={boundary}";
+
             var tempPath = platform.GetUploadTempFilePath(request);
+
             this.logger.LogInformation("Writing temp form data body to " + tempPath);
 
             using (var fs = new FileStream(tempPath, FileMode.Create))

--- a/src/Shiny.Net.Http/Platforms/iOS/PlatformExtensions.cs
+++ b/src/Shiny.Net.Http/Platforms/iOS/PlatformExtensions.cs
@@ -37,7 +37,7 @@ namespace Shiny.Net.Http
             return tempPath;
         }
 
-        public static NSUrlRequest ToNative(this HttpTransferRequest request)
+        public static NSMutableUrlRequest ToNative(this HttpTransferRequest request)
         {
             var url = NSUrl.FromString(request.Uri);
             var native = new NSMutableUrlRequest(url)


### PR DESCRIPTION
### Description of Change ###

Added content-type to NsUrlRequest because it was using application/octet-stream, which causes an exception in the asp.net backend. It's also different from the Android upload which uses multipart/form-data.

I also noticed that OnComplete was called while the upload failed with an internal exception. (Haven't looked into that issue yet)

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #782 

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->
- iOS

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
- [X] Sent to DEV branch