### PR TITLE
Bug fix: Environment.NewLine causes file uploads to fail to linux web api

### DIFF
--- a/src/Shiny.Net.Http/Platforms/iOS/PlatformExtensions.cs
+++ b/src/Shiny.Net.Http/Platforms/iOS/PlatformExtensions.cs
@@ -20,7 +20,7 @@ namespace Shiny.Net.Http
 
 
         public static void WriteLine(this Stream stream)
-            => stream.Write(Encoding.Default.GetBytes(Environment.NewLine));
+            => stream.Write(Encoding.Default.GetBytes("\r\n"));
 
 
         public static string GetUploadTempFilePath(this IPlatform platform, HttpTransferRequest request)


### PR DESCRIPTION
### Description of Change ###
Replaced Environment.NewLine with \r\n because the uploads fail when the web service is run on linux.

web api throws exception:
```
2021-12-03T11:35:34.829989553Z       System.IO.InvalidDataException: Line length limit 100 exceeded.
2021-12-03T11:35:34.830004953Z          at Microsoft.AspNetCore.WebUtilities.BufferedReadStream.ReadLineAsync(Int32 lengthLimit, CancellationToken cancellationToken)
2021-12-03T11:35:34.830009953Z          at Microsoft.AspNetCore.WebUtilities.MultipartReaderStream.ReadAsync(Byte[] buffer, Int32 offset, Int32 count, CancellationToken cancellationToken)
2021-12-03T11:35:34.830013953Z          at Microsoft.AspNetCore.WebUtilities.StreamHelperExtensions.DrainAsync(Stream stream, ArrayPool`1 bytePool, Nullable`1 limit, CancellationToken cancellationToken)
2021-12-03T11:35:34.830017653Z          at Microsoft.AspNetCore.WebUtilities.MultipartReader.ReadNextSectionAsync(CancellationToken cancellationToken)
2021-12-03T11:35:34.830032253Z          at Microsoft.AspNetCore.Http.Features.FormFeature.InnerReadFormAsync(CancellationToken cancellationToken)
2021-12-03T11:35:34.831223646Z          at Microsoft.AspNetCore.Http.Features.FormFeature.ReadForm()
2021-12-03T11:35:34.831255446Z          at Microsoft.AspNetCore.Http.DefaultHttpRequest.get_Form()
```

Which is caused by the Environment.NewLine as I understand from this StackOverflow question: https://stackoverflow.com/questions/44642701/microsoft-aspnetcore-webutilities-line-length-limit-100-exceeded

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral Changes ###
None

### Testing Procedure ###

### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
- [X] Sent to DEV branch