### PR TITLE
Added extra white lines because the file is malformed on the web server side

### DIFF
--- a/src/Shiny.Net.Http/Platforms/iOS/HttpTransferManager.cs
+++ b/src/Shiny.Net.Http/Platforms/iOS/HttpTransferManager.cs
@@ -71,7 +71,7 @@ namespace Shiny.Net.Http
             if (request.HttpMethod != System.Net.Http.HttpMethod.Post && request.HttpMethod != System.Net.Http.HttpMethod.Put)
                 throw new ArgumentException($"Invalid Upload HTTP Verb {request.HttpMethod} - only PUT or POST are valid");
 
-            var boundary = Guid.NewGuid().ToString();
+            var boundary = Guid.NewGuid().ToString("N");
 	            
             var native = request.ToNative();
             native["Content-Type"] = $"multipart/form-data; boundary={boundary}";
@@ -99,8 +99,9 @@ namespace Shiny.Net.Http
                     fs.Write("--" + boundary);
                     fs.Write($"Content-Type: application/octet-stream");
                     fs.Write($"Content-Disposition: form-data; name=\"blob\"; filename=\"{request.LocalFile.Name}\"");
-
+                    fs.WriteLine();
                     await uploadFile.CopyToAsync(fs);
+                    fs.WriteLine();
                     fs.Write($"--{boundary}--");
                 }
             }


### PR DESCRIPTION
### Description of Change ###

Added extra white lines to the file portion of the post request because the boundary ending was incorporated in the saved file, resulting in a corrupt file on the server. Also added a white line at the beginning of the file part because I was missing some data at the beginning of the saved file.
Don't know if this is a linux only issue.

Lastly I changed the boundary Guid to have no hyphens.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #782 

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
- [X] Sent to DEV branch