### PR TITLE
Retrieve the MTU of a connected central

### DIFF
--- a/src/Shiny.BluetoothLE.Hosting/IPeripheral.cs
+++ b/src/Shiny.BluetoothLE.Hosting/IPeripheral.cs
@@ -9,6 +9,8 @@ namespace Shiny.BluetoothLE.Hosting
         // I can get this on iOS and Droid
         string Uuid { get; }
 
+        int Mtu { get; }
+
         /// <summary>
         /// You can set any data you want here
         /// </summary>

--- a/src/Shiny.BluetoothLE.Hosting/Platforms/Android/GattCharacteristic.cs
+++ b/src/Shiny.BluetoothLE.Hosting/Platforms/Android/GattCharacteristic.cs
@@ -242,6 +242,23 @@ namespace Shiny.BluetoothLE.Hosting
         }
 
 
+        void SetupMtuChanged()
+        {
+            this.context
+                .MtuChanged
+                .Subscribe(ch =>
+                {
+                    if (this.subscribers.ContainsKey(ch.Device.Address))
+                    {
+                        var peripheral = this.subscribers[ch.Device.Address] as Peripheral;
+
+                        peripheral.UpdateMtuSize(ch.Mtu);
+                    }
+                })
+                .DisposedBy(this.disposer);
+        }
+
+
         IPeripheral GetOrAdd(BluetoothDevice native)
         {
             lock (this.subscribers)

--- a/src/Shiny.BluetoothLE.Hosting/Platforms/Android/Internals/GattServerContext.cs
+++ b/src/Shiny.BluetoothLE.Hosting/Platforms/Android/Internals/GattServerContext.cs
@@ -89,11 +89,13 @@ namespace Shiny.BluetoothLE.Hosting.Internals
         //}
 
 
-        //public event EventHandler<MtuChangedEventArgs> MtuChanged;
-        //public override void OnMtuChanged(BluetoothDevice peripheral, int mtu)
-        //{
-        //    this.MtuChanged?.Invoke(this, new MtuChangedEventArgs(peripheral, mtu));
-        //}
+        public Subject<MtuChangedEventArgs> MtuChanged { get; } = new Subject<MtuChangedEventArgs>();
+        public override void OnMtuChanged(BluetoothDevice peripheral, int mtu)
+        {
+            base.OnMtuChanged(peripheral, mtu);
+
+            this.MtuChanged.OnNext(new MtuChangedEventArgs(peripheral, mtu));
+        }
 
 
         //public override void OnServiceAdded(ProfileState status, BluetoothGattService service)

--- a/src/Shiny.BluetoothLE.Hosting/Platforms/Android/Internals/MtuChangedEventArgs.cs
+++ b/src/Shiny.BluetoothLE.Hosting/Platforms/Android/Internals/MtuChangedEventArgs.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Android.Bluetooth;
+
+namespace Shiny.BluetoothLE.Hosting.Internals
+{
+    public class MtuChangedEventArgs : EventArgs
+    {
+        public MtuChangedEventArgs(BluetoothDevice device, int mtu)
+        {
+            this.Device = device;
+            this.Mtu = mtu;
+        }
+
+
+        public BluetoothDevice Device { get; }
+        public int Mtu { get; }
+    }
+}

--- a/src/Shiny.BluetoothLE.Hosting/Platforms/Android/Peripheral.cs
+++ b/src/Shiny.BluetoothLE.Hosting/Platforms/Android/Peripheral.cs
@@ -7,6 +7,7 @@ namespace Shiny.BluetoothLE.Hosting
 {
     public class Peripheral : IPeripheral
     {
+        int mtu = 20; // Default MTU size from BLE spec
         readonly Lazy<string> deviceUuidLazy;
 
 
@@ -33,5 +34,12 @@ namespace Shiny.BluetoothLE.Hosting
         public BluetoothDevice Native { get; }
         public string Uuid => this.deviceUuidLazy.Value;
         public object Context { get; set; }
+        public int Mtu => this.mtu;
+
+
+        public void UpdateMtuSize(int size)
+        {
+            this.mtu = size;
+        }
     }
 }

--- a/src/Shiny.BluetoothLE.Hosting/Platforms/Uwp/Peripheral.cs
+++ b/src/Shiny.BluetoothLE.Hosting/Platforms/Uwp/Peripheral.cs
@@ -6,13 +6,18 @@ namespace Shiny.BluetoothLE.Hosting
 {
     public class Peripheral : IPeripheral
     {
+        int mtu = 20; // Default MTU size from BLE spec
+
+
         public Peripheral(GattSession session)
         {
             this.Uuid = session.DeviceId.Id;
+            this.mtu = Convert.ToInt32(session.MaxPduSize);
         }
 
 
         public string Uuid { get; }
         public object Context { get; set; }
+        public int Mtu => this.mtu;
     }
 }

--- a/src/Shiny.BluetoothLE.Hosting/Platforms/ios+macos/Peripheral.cs
+++ b/src/Shiny.BluetoothLE.Hosting/Platforms/ios+macos/Peripheral.cs
@@ -16,5 +16,6 @@ namespace Shiny.BluetoothLE.Hosting
         public string Uuid { get; }
         public CBCentral Central { get; }
         public object Context { get; set; }
+        public int Mtu => (int)this.Central.MaximumUpdateValueLength;
     }
 }


### PR DESCRIPTION
### Description of Change ###

An integer property has been added to provide the MTU size of the connected peripheral within the Hosting library.

iOS leverages the `CBCentral.MaximumUpdateValueLength` property.

Windows leverages the `GattSession.MaxPduSize` property.

Android was the most complicated to solve. The solution I have gone for on Android is to simply use the Bluetooth LE default MTU size of 20. If the `OnMtuChanged(BluetoothDevice peripheral, int mtu)` method is called within the `GattServerContext`, then the default MTU value that was originally provided will be updated.

### API Changes ###

Added `Shiny.BluetoothLE.Hosting.IPeripheral.Mtu: int`

### Platforms Affected ### 

- All

### Behavioral Changes ###

None

### Testing Procedure ###

iOS is the only platform that I have the capability to test on.

To perform the test, I connected one iOS device to another and wrote out the `IPeripheral.Mtu` value when the client device subscribed to a notification on the server.

An example project can be found here:
https://github.com/rhinohq/ShinyBluetoothTest

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Sent to DEV branch