### PR TITLE
fixes KeyNotFoundException on left operand evaluation ??=

### DIFF
--- a/src/Shiny.BluetoothLE/Managed/ManagedPeripheral.cs
+++ b/src/Shiny.BluetoothLE/Managed/ManagedPeripheral.cs
@@ -114,7 +114,7 @@ namespace Shiny.BluetoothLE.Managed
             {
                 lock (this.observables)
                 {
-                    this.observables[key] ??= this.Peripheral
+                    this.observables[key] = this.Peripheral
                         .WhenConnected()
                         .Select(x => this.GetChar(serviceUuid, characteristicUuid))
                         .Switch()


### PR DESCRIPTION
### Description of Change ###
fixes GetNotificationObservable() 

### Issues Resolved ### 
- fixes KeyNotFoundException thrown on GetNotificationObservable() subscription.
Since the key does not exist, checked above with ContainsKey() the left operand
evaluation ??= before assignment throws a KeyNotFoundException.

### API Changes ### 
 None

### Platforms Affected ### 
- All

### Behavioral Changes ###
None