### PR TITLE
iOS BLE restore null check fix

### DIFF
--- a/src/Shiny.BluetoothLE/Platforms/Apple/Internals/ManagerContext.cs
+++ b/src/Shiny.BluetoothLE/Platforms/Apple/Internals/ManagerContext.cs
@@ -79,6 +79,10 @@ namespace Shiny.BluetoothLE.Internals
 #if __IOS__
             //this.Manager = central;
             var peripheralArray = (NSArray)dict[CBCentralManager.RestoredStatePeripheralsKey];
+
+            if (peripheralArray == null)
+                return;
+
             for (nuint i = 0; i < peripheralArray.Count; i++)
             {
                 var item = peripheralArray.GetItem<CBPeripheral>(i);


### PR DESCRIPTION
### Description of Change ###

Added null check to `ManagerContextWillRestoreState(CBCentralManager central, NSDictionary dict)`.

### Issues Resolved ### 

- No issue for this. Occurs when iOS tries to restore a session that did not have any connected peripherals in it.

Stack Trace:
`ManagerContext.WillRestoreState (CoreBluetooth.CBCentralManager central, Foundation.NSDictionary dict)
AsyncMethodBuilderCore+<>c.<ThrowAsync>b__7_0 (System.Object state)
NSAsyncSynchronizationContextDispatcher.Apply ()
(wrapper managed-to-native) UIKit.UIApplication.UIApplicationMain(int,string[],intptr,intptr)
UIApplication.Main (System.String[] args, System.String principalClassName, System.String delegateClassName)
Application.Main (System.String[] args)`

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioural Changes ###

None

### Testing Procedure ###

I found the issue would always occur when the app crashed or got killed by the debugger. Upon trying to restart the Bluetooth session when the app restarted, iOS would try to restore the old session. This would always give me a `NullReferenceException` resulting in an endless crash loop.

Performing the above actions is the best way to test this error/fix.

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Sent to DEV branch