### PR TITLE
Ability to See Running Jobs and Start Android HTTP Transfer Immediately

### DIFF
--- a/samples/Sample.Maui/Jobs/ListPage.xaml
+++ b/samples/Sample.Maui/Jobs/ListPage.xaml
@@ -12,10 +12,14 @@
     </ContentPage.ToolbarItems>
 
     <ContentPage.Content>
-        <Grid RowDefinitions="*, Auto, Auto, Auto">
+        <Grid RowDefinitions="Auto, *, Auto, *, Auto, Auto, Auto">
+            <Label Text="Registered Jobs:"
+                   FontSize="Title"
+                   Grid.Row="0"/>
+
             <RefreshView IsRefreshing="{Binding IsBusy}"
                          Command="{Binding LoadJobs}"
-                         Grid.Row="0">
+                         Grid.Row="1">
                 <CollectionView ItemsSource="{Binding Jobs}"
                                 SelectedItem="{Binding SelectedJob}"
                                 SelectionMode="Single">
@@ -36,18 +40,41 @@
                 </CollectionView>
             </RefreshView>
 
+            <Label Text="Running Jobs:"
+                   FontSize="Title"
+                   Grid.Row="2"/>
+
+            <CollectionView ItemsSource="{Binding RunningJobs}"
+                            SelectionMode="None"
+                            Grid.Row="3">
+
+                <CollectionView.EmptyView>
+                    <Label Text="No Running Jobs"
+                            Style="{StaticResource NoDataLabel}" />
+                </CollectionView.EmptyView>
+
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="shiny:JobInfo">
+                        <StackLayout>
+                            <Label Text="{Binding Identifier}" FontSize="Large" />
+                            <BoxView Style="{StaticResource HR}"/>
+                        </StackLayout>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+
             <Label Text="{Binding RunningText}"
                    HorizontalOptions="CenterAndExpand"
                    HorizontalTextAlignment="Center"
-                   Grid.Row="1" />
+                   Grid.Row="4" />
 
             <Button Text="Cancel All Jobs"
                     Command="{Binding CancelAllJobs}"
-                    Grid.Row="2" />
+                    Grid.Row="5" />
 
             <Button Text="Run All Jobs"
                     Command="{Binding RunAllJobs}"
-                    Grid.Row="3" />
+                    Grid.Row="6" />
         </Grid>
     </ContentPage.Content>
 </ContentPage>

--- a/samples/Sample.Maui/Jobs/ListViewModel.cs
+++ b/samples/Sample.Maui/Jobs/ListViewModel.cs
@@ -13,6 +13,7 @@ public class ListViewModel : ViewModel
     {
         this.jobManager = jobManager;
         this.Create = this.Navigation.Command("JobsCreate");
+        this.RunningJobs = this.jobManager.RunningJobs;
 
         this.LoadJobs = ReactiveCommand.Create(() =>
             this.Jobs = jobManager.GetJobs()
@@ -54,6 +55,7 @@ public class ListViewModel : ViewModel
     public ICommand Create { get; }
 
     [Reactive] public IList<JobInfo> Jobs { get; private set; }
+    [Reactive] public INotifyReadOnlyCollection<JobInfo> RunningJobs { get; private set; }
     [Reactive] public string RunningText { get; private set; }
     [Reactive] public JobInfo? SelectedJob { get; set; }
 

--- a/src/Shiny.Jobs/IJobManager.cs
+++ b/src/Shiny.Jobs/IJobManager.cs
@@ -35,6 +35,12 @@ public interface IJobManager
 
 
     /// <summary>
+    /// List of jobs currently running
+    /// </summary>
+    INotifyReadOnlyCollection<JobInfo> RunningJobs { get; }
+
+
+    /// <summary>
     /// Requests/ensures appropriate platform permissions where necessary
     /// </summary>
     /// <returns></returns>
@@ -57,6 +63,22 @@ public interface IJobManager
     /// <param name="cancelToken"></param>
     /// <returns></returns>
     Task<JobRunResult> Run(string jobIdentifier, CancellationToken cancelToken = default);
+    
+    
+    /// <summary>
+    /// Checks to see if a job is currently running
+    /// </summary>
+    /// <param name="jobIdentifier"></param>
+    /// <returns></returns>
+    bool IsJobRunning(string jobIdentifier);
+
+
+    /// <summary>
+    /// Checks to see if a job is currently running
+    /// </summary>
+    /// <param name="jobInfo"></param>
+    /// <returns></returns>
+    bool IsJobRunning(JobInfo jobInfo);
 
 
     /// <summary>

--- a/src/Shiny.Net.Http/Platforms/Android/HttpTransferManager.cs
+++ b/src/Shiny.Net.Http/Platforms/Android/HttpTransferManager.cs
@@ -49,6 +49,12 @@ public class HttpTransferManager : IHttpTransferManager
             DateTimeOffset.UtcNow
         );
         this.repository.Insert(transfer);
+
+        // Run job if it is not already running
+        this.jobManager
+            .RunJobAsTask(typeof(TransferJob).FullName)
+            .Forget();
+            
         return transfer;
     }
 


### PR DESCRIPTION
### Description of Change ###

So this probably should have been 2 separate PRs but I wanted to see if there was an appetite for either piece of functionality first.

So this started as what I thought would be a small change to run the Android Transfer job (if not already running) upon queuing a new transfer so one would not have a potentially 30 second wait before the transfer started. This created two issues:

1. I did not realise that ad hoc running of a job awaited the entire job. This required a safe 'fire and forget' system.
2. Once we had this, Shiny.Jobs needed to be aware of running jobs in order to not run a job that was already running.

The first issue was a trivial one to overcome thanks to this article by Gérald Barré:
https://www.meziantou.net/fire-and-forget-a-task-in-dotnet.htm

The second one required me to create an in memory list of the running jobs that was populated/unpopulated by the `IJobManager.JobStarted` and `IJobManager.JobFinished` subjects. A conditional was then added in `IJobManager.Run()` to check if the job is in that list before running it. I do think it might be better to have a boolean parameter on this method, that defaults to false, that allows multiple instances of the same job to run at once if someone desires it, however. Let me know thoughts on this and I will happily add that to this PR.

The aforementioned list is an ObservableList but there is arguably not a lot of need for this and that a conventional list would do fine.

It is worth noting that I have updated the Sample.Maui project to show the running jobs.

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
`IJobManager.RunningJobs: INotifyReadOnlyCollection<JobInfo>`

`bool IJobManager.IsJobRunning(string jobIdentifier)`
`bool IJobManager.IsJobRunning(JobInfo jobInfo)`

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- All

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

- Queuing a a transfer on Android will immediately run the transfer job if it is not already running. This is instead of waiting for the job that runs every 30 seconds.
- You can now see a live list of running jobs and subscribe to changes of it.
- You can no longer run a job that is currently running.

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Hitting 'Start Transfer' on Android in Sample.Maui and then visiting the Shiny.Jobs list page.

### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
- [X] Sent to a v(branch) or DEV branch