### PR TITLE
#1316 - Fixed iOS crash when tap on push notification alert while app…

### DIFF
--- a/src/Shiny.Push/Platforms/Apple/PushManager.cs
+++ b/src/Shiny.Push/Platforms/Apple/PushManager.cs
@@ -186,7 +186,16 @@ public class PushManager : NotifyPropertyChanged,
                 x => x.OnEntry(data),
                 this.logger
             )
-            .ContinueWith(_ => completionHandler.Invoke());
+            .ContinueWith(_ =>
+            {
+                // This needs be invoked on MainThread,
+                // otherwise iOS app crashes if we tap on push notification alert
+                // from notification center, while App in Active state.
+                UIDevice.CurrentDevice.InvokeOnMainThread(() =>
+                {
+                    completionHandler.Invoke();
+                });
+            });
     }
 
 


### PR DESCRIPTION
… is Active.

### Description of Change ###
iOS app was crashing on OnDidReceiveNotificationResponse's completion handler. I invoked it on Main thread.

### Issues Resolved ### 
- fixes #1316 

### API Changes ###
 None

### Platforms Affected ### 
- iOS

### Behavioral Changes ###
None

### Testing Procedure ###
Run project in iOS device.
Keep App Active
Send push notification from Azure push hub.
Drag down to open the Push Notification Center tray
Tap on the push notification.
App will crash/freeze.


### PR Checklist ###

- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
- [ ] Sent to a v(branch) or DEV branch