### PR TITLE
Use ServiceCompat to start and stop android foreground service

### DIFF
--- a/src/Shiny.Beacons/Platforms/Android/ShinyBeaconMonitoringService.cs
+++ b/src/Shiny.Beacons/Platforms/Android/ShinyBeaconMonitoringService.cs
@@ -14,6 +14,7 @@ public class ShinyBeaconMonitoringService : ShinyAndroidForegroundService<IBeaco
 {
     public static bool IsStarted { get; private set; }
     BackgroundTask? backgroundTask;
+    protected override ForegroundService StartForegroundServiceType => ForegroundService.TypeLocation;
 
 
     protected override void OnStart(Intent? intent)

--- a/src/Shiny.Locations/Platforms/Android/ShinyGpsService.cs
+++ b/src/Shiny.Locations/Platforms/Android/ShinyGpsService.cs
@@ -14,6 +14,7 @@ namespace Shiny.Locations;
 public class ShinyGpsService : ShinyAndroidForegroundService<IGpsManager, IGpsDelegate>
 {
     public static bool IsStarted { get; private set; }
+    protected override ForegroundService StartForegroundServiceType => ForegroundService.TypeLocation;
 
 
     protected override void OnStart(Intent? intent)

--- a/src/Shiny.Net.Http/Platforms/Android/HttpTransferService.cs
+++ b/src/Shiny.Net.Http/Platforms/Android/HttpTransferService.cs
@@ -14,6 +14,7 @@ namespace Shiny.Net.Http;
 public class HttpTransferService : ShinyAndroidForegroundService<IHttpTransferManager, IHttpTransferDelegate>
 {
     public static bool IsStarted { get; private set; }
+    protected override ForegroundService StartForegroundServiceType => ForegroundService.TypeDataSync;
 
 
     protected override void OnStart(Intent? intent)


### PR DESCRIPTION
### Description of Change ###

Some time ago I created the bug #1344 that was fixed very quickly (thanks for that!). When I tested it, I noticed that after these changes the foreground service notification didn't appear on older android versions and that because of this the GPS tracking didn't work anymore when the app is in the background.
I finally had the time to look at why this is happening.
I am not an Android expert, but as far as I understand the documentation, the [ServiceCompat](https://developer.android.com/reference/androidx/core/app/ServiceCompat#startForeground(android.app.Service,int,android.app.Notification,int)) class does all the version checks for us. Using it makes the code much simpler and in my tests, it also worked on older Android versions.

### Issues Resolved ### 

I haven't created an issue for this yet, but I can if you prefer to have one.

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral Changes ###

Before these changes there was no foreground service notification shown on Android versions < API level 31.
Now, the notification is shown on all supported platforms.

In addition, the foreground service type is passed to `StartForeground`. I am not 100% sure if this is required, but as I understand the documentation, it should be defined in the manifest AND passed in the call to `StartForeground`.

### Testing Procedure ###

I have tested it with the sample I have created for the previous issue (https://github.com/berhir/ShinyLocationRestartIssue) and referenced the shiny packages with my changes.

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Sent to a v(branch) or DEV branch