### PR TITLE
Prevent multiple parallel transfer loops

### DIFF
--- a/samples/Sample.Api/Controllers/PushController.cs
+++ b/samples/Sample.Api/Controllers/PushController.cs
@@ -15,14 +15,14 @@ public class PushController : Controller
     }
 
 
-    [HttpPost]
+    [HttpPost("register")]
     public async Task<IActionResult> Register([FromBody] RegisterArgs args)
     {
         return this.Ok(null);
     }
 
 
-    [HttpPost]
+    [HttpPost("send")]
     public async Task<ActionResult<object>> Send([FromBody] SendArgs args)
     {
         return this.Ok(null);

--- a/samples/Sample.Maui/Platforms/Android/AndroidManifest.xml
+++ b/samples/Sample.Maui/Platforms/Android/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />

--- a/src/Shiny.Net.Http/Platforms/Android/HttpTransferService.cs
+++ b/src/Shiny.Net.Http/Platforms/Android/HttpTransferService.cs
@@ -19,8 +19,11 @@ public class HttpTransferService : ShinyAndroidForegroundService<IHttpTransferMa
 
     protected override void OnStart(Intent? intent)
     {
-        this.GetService<HttpTransferProcess>().Run(() => this.Stop());
-        IsStarted = true;
+        if (!IsStarted)
+        {
+            this.GetService<HttpTransferProcess>().Run(() => this.Stop());
+            IsStarted = true;
+        }
     }
 
 


### PR DESCRIPTION
### Description of Change ###

When multiple http transfers get added within a short time, the http transfer loops gets started multiple times in parallel and some files will be uploaded more than once.

The problem is that `this.platform.StartService(typeof(HttpTransferService), true)` in the `HttpTransferManager` only triggers the service start but does not wait until it was fully started. That's why the `OnStart` of the `HttpTransferService` gets called multiple times.
The good thing is that it seems `OnStart` is always called sequentially and therefor a simple check if `IsStarted` is `true` is enough to prevent starting the loop multiple times.

I also fixed two issues in the sample projects to be able to execute it.

### Issues Resolved ### 
 NA

### API Changes ###
 
 None

### Platforms Affected ### 
 Android

### Behavioral Changes ###
There is now only one http transfer loop running instead of multiple parallel loops.

### Testing Procedure ###
To reproduce the issue and test the fix, multiple http transfers must be added within a short time.
I was able to reproduce it in the sample app by adding 5 transfers in a loop.
Just update the `HttpTransfersViewModel` file:
```cs
        this.AddUpload = ReactiveCommand.CreateFromTask(async () =>
        {
            var path = GenerateFile(50);

            for (var index = 0; index < 5; index++)
            {
                await this.manager.Queue(new HttpTransferRequest(
                    Guid.NewGuid().ToString(),
                    this.GetUrl(true),
                    true,
                    path
                ));
            }
        });
```


### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Sent to a v(branch) or DEV branch