### PR TITLE
set the usage when creating notification channels on Android

### DIFF
--- a/src/Shiny.Notifications/Platforms/Android/ChannelManager.cs
+++ b/src/Shiny.Notifications/Platforms/Android/ChannelManager.cs
@@ -73,6 +73,10 @@ public class ChannelManager : IChannelManager, IShinyComponentStartup
 
             native.SetBypassDnd(true);
         }
+        else
+        {
+            attrBuilder.SetUsage(AudioUsageKind.Notification);
+        }
 
         switch (channel.Sound)
         {


### PR DESCRIPTION
### Description of Change ###

When channels are created in Android, media volume is what is used, instead of using notification volume. Set the usage to AudioUsageKind.Notification so that all of the volumes work the proper way and the correct sounds are presented to the user.

### Issues Resolved ### 

None

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral Changes ###

None

### Testing Procedure ###

Create a new channel on Android and make sure that Notification Volume controls the sound, and not Media Volume.

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Sent to a v(branch) or DEV branch