### PR TITLE
[Android] Verified if the FirebaseApp is not already running before initialization.

### DIFF
--- a/src/Shiny.Push/Platforms/Android/PushManager.cs
+++ b/src/Shiny.Push/Platforms/Android/PushManager.cs
@@ -199,20 +199,26 @@ public class PushManager : NotifyPropertyChanged,
 
         if (this.config.UseEmbeddedConfiguration)
         {
-            FirebaseApp.InitializeApp(this.platform.AppContext);
-            if (FirebaseApp.Instance == null)
-                throw new InvalidOperationException("Firebase did not initialize.  Ensure your google.services.json is property setup.  Install the nuget package `Xamarin.GooglePlayServices.Tasks` into your Android head project, restart visual studio, and then set your google-services.json to GoogleServicesJson");
+            if (!this.IsFirebaseAappAlreadyInitialized())
+            {
+                FirebaseApp.InitializeApp(this.platform.AppContext);
+                if (FirebaseApp.Instance == null)
+                    throw new InvalidOperationException("Firebase did not initialize.  Ensure your google.services.json is property setup.  Install the nuget package `Xamarin.GooglePlayServices.Tasks` into your Android head project, restart visual studio, and then set your google-services.json to GoogleServicesJson");
+            }
         }
         else
         {
-            var options = new FirebaseOptions.Builder()
-                .SetApplicationId(this.config.AppId)
-                .SetProjectId(this.config.ProjectId)
-                .SetApiKey(this.config.ApiKey)
-                .SetGcmSenderId(this.config.SenderId)
-                .Build();
+            if (!this.IsFirebaseAappAlreadyInitialized())
+            {
+                var options = new FirebaseOptions.Builder()
+                        .SetApplicationId(this.config.AppId)
+                        .SetProjectId(this.config.ProjectId)
+                        .SetApiKey(this.config.ApiKey)
+                        .SetGcmSenderId(this.config.SenderId)
+                        .Build();
 
-            FirebaseApp.InitializeApp(this.platform.AppContext, options);
+                FirebaseApp.InitializeApp(this.platform.AppContext, options);
+            }
         }
 
         ShinyFirebaseService.NewToken = async token =>
@@ -257,6 +263,22 @@ public class PushManager : NotifyPropertyChanged,
         };
 
         this.initialized = true;
+    }
+
+    bool IsFirebaseAappAlreadyInitialized()
+    {
+        var isAppInitialized = false;
+        var firebaseApps = FirebaseApp.GetApps(this.platform.AppContext);
+        foreach (var app in firebaseApps)
+        {
+            if (string.Equals(app.Name, FirebaseApp.DefaultAppName))
+            {
+                isAppInitialized = true;
+                break;
+            }
+        }
+
+        return isAppInitialized;
     }
 
 


### PR DESCRIPTION
### Description of Change ###

- Addressed an issue where if the FirebaseApp is initialized before the RequestNativeToken in Android is invoked, the FirebaseApp fails to load.

### Issues Resolved ### 

- This resolves an issue where Google Crashlytics needs FirebaseApp instance in Maui App's onCreate handler either by using `ConfigureLifecycleEvents` in MauiProgram or by implementing `Shiny.Hosting.IAndroidLifecycle.IOnActivityOnCreate`.
- Avoids `FirebaseApp name [DEFAULT] already exists!` error with following StackTrace:

```CSharp
 at Java.Interop.JniEnvironment.StaticMethods.CallStaticObjectMethod(JniObjectReference type, JniMethodInfo method, JniArgumentValue* args) in /Users/runner/work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/obj/Release/net7.0/JniEnvironment.g.cs:line 21452
    at Java.Interop.JniPeerMembers.JniStaticMethods.InvokeObjectMethod(String encodedMember, JniArgumentValue* parameters) in /Users/runner/work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniStaticMethods.cs:line 165
    at Firebase.FirebaseApp.InitializeApp(Context context, FirebaseOptions options) in C:\a\_work\1\s\generated\com.google.firebase.firebase-common\obj\Release\net7.0-android\generated\src\Firebase.FirebaseApp.cs:line 627
    at Shiny.Push.PushManager.DoInit()
    at Shiny.Push.PushManager.RequestNativeToken()
    at Shiny.Push.PushManager.RequestAccess(CancellationToken cancelToken)
```

### API Changes ###
 None

### Platforms Affected ### 
- Android

### Behavioral Changes ###
None

### Testing Procedure ###
None

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Sent to a v(branch) or DEV branch