### PR TITLE
Fix for sending scheduled local notifications

### DIFF
--- a/samples/Sample.Maui/Platforms/Android/AndroidManifest.xml
+++ b/samples/Sample.Maui/Platforms/Android/AndroidManifest.xml
@@ -12,7 +12,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARMS" android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARMS" android:maxSdkVersion="33" />
     <uses-permission android:name="android.permission.USE_EXACT_ALARMS" />
 
     <uses-permission android:name="android.permission.BLUETOOTH_SCAN" android:usesPermissionFlags="neverForLocation" />

--- a/src/Shiny.Notifications/Platforms/Android/NotificationManager.cs
+++ b/src/Shiny.Notifications/Platforms/Android/NotificationManager.cs
@@ -138,46 +138,46 @@ public partial class NotificationManager : INotificationManager,
     public async Task Send(Notification notification)
     {
         notification.AssertValid();
-        var android = notification.TryToNative<AndroidNotification>();
+        var androidNotification = notification.TryToNative<AndroidNotification>();
 
         // TODO: should I cancel an existing id if the user is setting it?
-        if (notification.Id == 0)
-            notification.Id = this.settings.IncrementValue("NotificationId");
+        if (androidNotification.Id == 0)
+            androidNotification.Id = this.settings.IncrementValue("NotificationId");
 
-        var channelId = notification.Channel ?? Channel.Default.Identifier;
+        var channelId = androidNotification.Channel ?? Channel.Default.Identifier;
         var channel = this.channelManager.Get(channelId);
         if (channel == null)
             throw new InvalidProgramException("No channel found for " + channelId);
 
-        var builder = this.manager.CreateNativeBuilder(android, channel!);
+        var builder = this.manager.CreateNativeBuilder(androidNotification, channel!);
 
-        if (notification.Geofence != null)
+        if (androidNotification.Geofence != null)
         {
             await this.geofenceManager.StartMonitoring(new GeofenceRegion(
-                AndroidNotificationProcessor.GetGeofenceId(notification),
-                notification.Geofence!.Center!,
-                notification.Geofence!.Radius!
+                AndroidNotificationProcessor.GetGeofenceId(androidNotification),
+                androidNotification.Geofence!.Center!,
+                androidNotification.Geofence!.Radius!
             ));
         }
-        else if (notification.RepeatInterval != null)
+        else if (androidNotification.RepeatInterval != null)
         {
             // calc first date if repeating interval
-            notification.ScheduleDate = notification.RepeatInterval!.CalculateNextAlarm();
+            androidNotification.ScheduleDate = androidNotification.RepeatInterval!.CalculateNextAlarm();
         }
 
-        if (notification.ScheduleDate == null && notification.Geofence == null)
+        if (androidNotification.ScheduleDate == null && androidNotification.Geofence == null)
         {
             var native = builder.Build();
-            this.manager.NativeManager.Notify(notification.Id, native);
+            this.manager.NativeManager.Notify(androidNotification.Id, native);
         }
         else
         {
             // ensure a channel is set
-            notification.Channel = channel!.Identifier;
-            this.repository.Set(notification);
+            androidNotification.Channel = channel!.Identifier;
+            this.repository.Set(androidNotification);
 
-            if (notification.ScheduleDate != null)
-                this.manager.SetAlarm(notification);
+            if (androidNotification.ScheduleDate != null)
+                this.manager.SetAlarm(androidNotification);
         }
     }
 


### PR DESCRIPTION
### Description of Change ###
Method `Send(Notification notification)` in android implementation of `INotificationManager` was storing shared type of `Notification` in `repository`, now it will store `Android Notification`.

### Issues Resolved ### 
- fixes #1406

### API Changes ###
 None

### Platforms Affected ### 
- Android

### Behavioral Changes ###
Now scheduled notifications should appear for the user on android platform.

### Testing Procedure ###
Don't know what to say just try to `notificationManager.Send(notification)` on android with `ScheduleDate` with and without this fix.

I recorded also video before and after fix:

https://github.com/shinyorg/shiny/assets/10498621/774a0d56-702c-4da9-af15-6e46276f9300


https://github.com/shinyorg/shiny/assets/10498621/8f7bacea-9123-418e-b15e-69ec711a9aa9


### PR Checklist ###

- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
- [ ] Sent to a v(branch) or DEV branch