### PR TITLE
ManagedScan improvements

### DIFF
--- a/src/Shiny.BluetoothLE/Managed/ManagedScan.cs
+++ b/src/Shiny.BluetoothLE/Managed/ManagedScan.cs
@@ -24,10 +24,15 @@ public class ManagedScan : IDisposable, IManagedScan
         => this.bleManager = bleManager;
 
 
-    public IEnumerable<IPeripheral> GetConnectedPeripherals() => this.list
-        .ToList()
-        .Where(x => x.Peripheral.Status == ConnectionState.Connected)
-        .Select(x => x.Peripheral);
+    public IEnumerable<IPeripheral> GetConnectedPeripherals()
+    {
+        lock (this.syncLock)
+        {
+            return this.list.ToList()
+                .Where(x => x.Peripheral.Status == ConnectionState.Connected)
+                .Select(x => x.Peripheral);
+        }
+    }
 
 
     public IObservable<(ManagedScanListAction Action, ManagedScanResult? ScanResult)> WhenScan() => this.actionSubj;
@@ -80,7 +85,9 @@ public class ManagedScan : IDisposable, IManagedScan
                         if (show)
                         {
                             var action = ManagedScanListAction.Update;
-                            var result = this.Peripherals.FirstOrDefault(x => x.Peripheral.Equals(scanResult.Peripheral));
+                            ManagedScanResult? result;
+                            lock (this.syncLock)
+                                result = this.Peripherals.FirstOrDefault(x => x.Peripheral.Equals(scanResult.Peripheral));
                             if (result == null)
                             {
                                 action = ManagedScanListAction.Add;
@@ -89,8 +96,6 @@ public class ManagedScan : IDisposable, IManagedScan
                                     ServiceUuids = scanResult.AdvertisementData?.ServiceUuids,
                                     ServiceData = scanResult.AdvertisementData?.ServiceData
                                 };
-                                lock (this.syncLock)
-                                    this.list.Add(result);
                             }
                             result.IsConnectable = scanResult.AdvertisementData?.IsConnectable;
                             result.ManufacturerData = scanResult.AdvertisementData?.ManufacturerData;
@@ -99,6 +104,11 @@ public class ManagedScan : IDisposable, IManagedScan
                             result.Rssi = scanResult.Rssi;
                             result.TxPower = scanResult.AdvertisementData?.TxPower;
                             result.LastSeen = DateTimeOffset.UtcNow;
+                            if (action == ManagedScanListAction.Add)
+                            {
+                                lock (this.syncLock)
+                                    this.list.Add(result);
+                            }
                             this.actionSubj.OnNext((action, result));
                         }
                     }
@@ -119,7 +129,9 @@ public class ManagedScan : IDisposable, IManagedScan
                     _ =>
                     {
                         var maxAge = DateTimeOffset.UtcNow.Subtract(clearTime.Value);
-                        var tmp = this.Peripherals.Where(x => x.LastSeen < maxAge).ToList();
+                        List<ManagedScanResult> tmp;
+                        lock (this.syncLock)
+                            tmp  = this.Peripherals.Where(x => x.LastSeen < maxAge).ToList();
 
                         foreach (var p in tmp)
                         {


### PR DESCRIPTION
Thanks for the awesome library. I have been using it for quite some time, I wanted to share some of the improvements we made to `ManagedScan`. Let me know if you have any questions or suggestions to do something differently.

### Description of Change ###
1. Add locking around all places where `list` is modified or enumerated, particularly while a scan is ongoing. This fixes an issue where if you scan for several minutes in a location where there are many devices, the scan will eventually deadlock.
2. Delay adding scan results to the `list` until after they are fully initialized. This prevents listeners of the `Peripherals.CollectionChanged` event from handling newly added `ManagedScanResult`s before their properties are fully initialized.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

None - please advise if you would like me to create an issue for either of the above.

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- All

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

For issue 1, go to a crowded place (coffee shop, etc) and start a `ManagedScan` with no predicate. Without this change, the scan will stop updating after several minutes (sometimes 10-15 mintues must elapse, if there are not many bluetooth devices appearing and disappearing). With this change, the scan can continue indefinitely.

For issue 2, while a `ManagedScan` is ongoing, add a handler to the `Peripherals.CollectionChanged` event. In the handler, you can see that when a new `ManagedScanResult` is added, the properties are often not initialized. With this change, the properties will always have been initialized.

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Sent to a v(branch) or DEV branch