### PR TITLE
BLE Client - Android reconnect fix

### DIFF
--- a/src/Shiny.BluetoothLE/Managed/ManagedScan.cs
+++ b/src/Shiny.BluetoothLE/Managed/ManagedScan.cs
@@ -24,10 +24,15 @@ public class ManagedScan : IDisposable, IManagedScan
         => this.bleManager = bleManager;
 
 
-    public IEnumerable<IPeripheral> GetConnectedPeripherals() => this.list
-        .ToList()
-        .Where(x => x.Peripheral.Status == ConnectionState.Connected)
-        .Select(x => x.Peripheral);
+    public IEnumerable<IPeripheral> GetConnectedPeripherals()
+    {
+        lock (this.syncLock)
+        {
+            return this.list.ToList()
+                .Where(x => x.Peripheral.Status == ConnectionState.Connected)
+                .Select(x => x.Peripheral);
+        }
+    }
 
 
     public IObservable<(ManagedScanListAction Action, ManagedScanResult? ScanResult)> WhenScan() => this.actionSubj;
@@ -80,7 +85,9 @@ public class ManagedScan : IDisposable, IManagedScan
                         if (show)
                         {
                             var action = ManagedScanListAction.Update;
-                            var result = this.Peripherals.FirstOrDefault(x => x.Peripheral.Equals(scanResult.Peripheral));
+                            ManagedScanResult? result;
+                            lock (this.syncLock)
+                                result = this.Peripherals.FirstOrDefault(x => x.Peripheral.Equals(scanResult.Peripheral));
                             if (result == null)
                             {
                                 action = ManagedScanListAction.Add;
@@ -89,8 +96,6 @@ public class ManagedScan : IDisposable, IManagedScan
                                     ServiceUuids = scanResult.AdvertisementData?.ServiceUuids,
                                     ServiceData = scanResult.AdvertisementData?.ServiceData
                                 };
-                                lock (this.syncLock)
-                                    this.list.Add(result);
                             }
                             result.IsConnectable = scanResult.AdvertisementData?.IsConnectable;
                             result.ManufacturerData = scanResult.AdvertisementData?.ManufacturerData;
@@ -99,6 +104,11 @@ public class ManagedScan : IDisposable, IManagedScan
                             result.Rssi = scanResult.Rssi;
                             result.TxPower = scanResult.AdvertisementData?.TxPower;
                             result.LastSeen = DateTimeOffset.UtcNow;
+                            if (action == ManagedScanListAction.Add)
+                            {
+                                lock (this.syncLock)
+                                    this.list.Add(result);
+                            }
                             this.actionSubj.OnNext((action, result));
                         }
                     }
@@ -119,7 +129,9 @@ public class ManagedScan : IDisposable, IManagedScan
                     _ =>
                     {
                         var maxAge = DateTimeOffset.UtcNow.Subtract(clearTime.Value);
-                        var tmp = this.Peripherals.Where(x => x.LastSeen < maxAge).ToList();
+                        List<ManagedScanResult> tmp;
+                        lock (this.syncLock)
+                            tmp  = this.Peripherals.Where(x => x.LastSeen < maxAge).ToList();
 
                         foreach (var p in tmp)
                         {

--- a/src/Shiny.BluetoothLE/Platforms/Android/BleManager.cs
+++ b/src/Shiny.BluetoothLE/Platforms/Android/BleManager.cs
@@ -298,13 +298,10 @@ public partial class BleManager : ScanCallback, IBleManager, IShinyStartupTask
     }
 
 
-    void Clear()
-    {
-        var connectedDevices = this.peripherals.Values.Select(x => x).ToList(); 
-        this.peripherals.Clear();
-        foreach (var dev in connectedDevices)
-            this.peripherals.TryAdd(dev.Native.Address!, dev);
-    }
+    void Clear() => this.peripherals
+        .Where(x => x.Value.Status != ConnectionState.Connected)
+        .ToList()
+        .ForEach(x => this.peripherals.TryRemove(x.Key, out var device));
 
 
     static string[] GetPlatformPermissions()


### PR DESCRIPTION
### Description of Change ###

This changes the behavior of the Android `BleManager.Clear` method to remove Peripherals which have been disconnected. The new implementation for Android matches the implementation that currently exists in iOS.

The problem that I have run into, which this PR fixes, is that in some cases, after an Android `Peripheral` has been connected to, and subsequently disconnected from, follow-up attempts to connect succeed. But there are problems with initializing MTU and enabling notifications. I attempted to create a simple sample app that showcases this, but found that it does not always happen. It does appear to be a lot more likely if, during the first connection, you set a large MTU and subscribe notifications on to lots of characteristics. This problem is not evident in iOS, which is why I made the change the way that I did.

Probably out of the scope of this PR is a change to actually subscribe to each `Peripheral.WhenDisconnected` and remove it from the list when that happens. But I think that is far more risky, and if users adhere to the "General Rules" 1 and 2 in the [BluetoothLE Best Practice/FAQ documentation](https://shinylib.net/client/ble/best-practices/), then the above fix should be sufficient.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

No issue is filed for this, please advise if you would like me to create an issue for this.

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Android:
1. Scan for & connect to peripheral
2. Change MTU
3. Call `EnableNotifications` on a lot of characteristics
4. Disconnect
5. Drop all references to the Peripheral
6. Repeat steps 1 & 2. In my case, without this fix, the MTU would never be successfully updated. The old updated MTU would still be cached by the android Native/Gatt, but the peripheral will have reset to the default of 20. If you skip updating the MTU, you can EnableNotifications on some characteristics, but data will not be updated by the peripheral if the payload is > 20 bytes.

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Sent to a v(branch) or DEV branch