### PR TITLE
Fix iOS Form Data Upload for Shiny 3.4.0

### DIFF
--- a/src/Shiny.Net.Http/Platforms/Apple/HttpTransferManager.cs
+++ b/src/Shiny.Net.Http/Platforms/Apple/HttpTransferManager.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Reactive.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using System.Web;
 using Foundation;
@@ -436,39 +437,40 @@ public class HttpTransferManager : NSUrlSessionDownloadDelegate,
         var httpMethod = request.GetHttpMethod();
         if (httpMethod != HttpMethod.Post && httpMethod != HttpMethod.Put)
             throw new ArgumentException($"Invalid Upload HTTP Verb {request.HttpMethod} - only PUT or POST are valid");
+        
+        var content = new MultipartFormDataContent();
 
-        var native = request.ToNative();
-        var boundary = Guid.NewGuid().ToString("N");
-        native["Content-Type"] = $"multipart/form-data; boundary=\"{boundary}\"";
-
+        if (request.HttpContent != null)
+        {
+            content.Add(new StringContent(
+                    request.HttpContent.Content,
+                    Encoding.GetEncoding(request.HttpContent.Encoding),
+                    request.HttpContent.ContentType
+                ),
+                request.HttpContent.ContentFormDataName ?? "value"
+            );
+        }
+        
         var tempPath = this.platform.GetUploadTempFilePath(request);
         this.logger.LogInformation("Writing temp form data body to " + tempPath);
 
-        using (var fs = new FileStream(tempPath, FileMode.Create))
-        { 
-            if (request.HttpContent != null)
-            {
-                fs.WriteString("--" + boundary);
-                fs.WriteString($"Content-Disposition: form-data; name=\"{request.HttpContent.ContentFormDataName ?? "value"}\"");
-                fs.WriteString($"Content-Type: {request.HttpContent.ContentType}; charset={request.HttpContent.Encoding}");
-                fs.WriteLine();
-                fs.WriteString(request.HttpContent.Content);
-                fs.WriteLine();
-            }
-
+        await using (var uploadFile = File.OpenRead(request.LocalFilePath))
+        {
             var fileName = Path.GetFileName(request.LocalFilePath);
-            fs.WriteString("--" + boundary);
             
-            fs.WriteString($"Content-Disposition: form-data; name=\"{request.FileFormDataName}\"; filename=\"{HttpUtility.UrlEncode(fileName)}\"; filename*=UTF-8''{fileName}");
-            fs.WriteLine();
-            using (var uploadFile = File.OpenRead(request.LocalFilePath))
-                await uploadFile.CopyToAsync(fs);
+            var innerContent = new StreamContent(uploadFile);
+            content.Add(innerContent, request.FileFormDataName, fileName);
+            innerContent.Headers.ContentDisposition!.FileNameStar = null;
 
-            fs.WriteLine();
-            fs.WriteString($"--{boundary}--");
+            await using (var fs = File.Create(tempPath))
+                await content.CopyToAsync(fs);
         }
-
+        
         this.logger.LogInformation("Form body written");
+
+        var native = request.ToNative();
+        native["Content-Type"] = content.Headers.ContentType!.ToString();
+        
         var tempFileUrl = NSUrl.CreateFileUrl(tempPath, null);
         this.configurator?.Configure(native, request);
 

--- a/src/Shiny.Net.Http/Platforms/Apple/HttpTransferManager.cs
+++ b/src/Shiny.Net.Http/Platforms/Apple/HttpTransferManager.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
+using System.Web;
 using Foundation;
 using Microsoft.Extensions.Logging;
 using Shiny.Hosting;
@@ -457,10 +458,8 @@ public class HttpTransferManager : NSUrlSessionDownloadDelegate,
 
             var fileName = Path.GetFileName(request.LocalFilePath);
             fs.WriteString("--" + boundary);
-
-            // TODO: escape/encode filename - add utf-8 version
-            //fileName = HttpUtility.UrlEncode(fileName);
-            fs.WriteString($"Content-Disposition: form-data; name={request.FileFormDataName}; filename={fileName}");
+            
+            fs.WriteString($"Content-Disposition: form-data; name=\"{request.FileFormDataName}\"; filename=\"{HttpUtility.UrlEncode(fileName)}\"; filename*=UTF-8''{fileName}");
             fs.WriteLine();
             using (var uploadFile = File.OpenRead(request.LocalFilePath))
                 await uploadFile.CopyToAsync(fs);


### PR DESCRIPTION
### Description of Change ###

Changes the creation of the form data payload of `HttpTransferManager` on iOS to use the built-in `MultipartFormDataContent` class. The rest of the process is unchanged, the content is still written to a temporary file for `NSURLSession` to upload.

### Issues Resolved ### 

I didn't create an issue for it, but there was a comment in the source code about it and we stumbled upon it in our App.

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral Changes ###

None, besides that the filename now gets correctly escaped.

### Testing Procedure ###
Upload a file with special characters in it's name and it should send the name correctly in the `filename*` and `filename` fields.

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Sent to a v(branch) or DEV branch (I sent it to the 3.4.0 branch, can rebase it on v3.0 if this is not correct)