### PR TITLE
Updated Peripheral.NotifyCharacteristic() on Android to use UUID for service and characteristic comparison

### DIFF
--- a/src/Shiny.BluetoothLE/Platforms/Android/Peripheral_Characteristics.cs
+++ b/src/Shiny.BluetoothLE/Platforms/Android/Peripheral_Characteristics.cs
@@ -108,7 +108,7 @@ public partial class Peripheral
                         }))
                         .Switch()
                         .Select(ch => this.notifySubj
-                            .Where(x => x.Equals(ch))
+                            .Where(x => x.Is(ch.Service!.Uuid!, ch.Uuid!))
                             .Select(x => this.ToResult(x, BleCharacteristicEvent.Notification))
                         )
                         .Switch()


### PR DESCRIPTION


### Description of Change ###

Updated Peripheral.NotifyCharacteristic() on Android to use UUID for service and characteristic comparison instead of BluetoothGattCharacteristic object comparison.


### Issues Resolved ### 

- fixes #1602 

### API Changes ###
 
 None

### Platforms Affected ### 

- Android


### Behavioral Changes ###

None

### Testing Procedure ###

On Android 16: connect to heart rate sensor, setup notifications using `Peripheral.NotifyCharacteristic()`, and verify that HR data is now coming through.

### PR Checklist ###

- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Sent to a v(branch) or DEV branch