### PR TITLE
Include path in URI to azure blob storage - add RemoteFileName to all…

### DIFF
--- a/src/Shiny.Net.Http/AzureBlobStorageUploadRequest.cs
+++ b/src/Shiny.Net.Http/AzureBlobStorageUploadRequest.cs
@@ -15,6 +15,7 @@ public class AzureBlobStorageUploadRequest(string localFilePath)
     public string? SharedAuthorizationKey { get; set; }
     public DateTimeOffset? AuthVersion { get; set; }
     public DateTimeOffset? AuthDate { get; set; }
+    public string? RemoteFileName { get; set; }
     
     public string? SasToken { get; set; }
     public Dictionary<string, string> Headers { get; } = new();
@@ -53,6 +54,11 @@ public class AzureBlobStorageUploadRequest(string localFilePath)
         return this;
     }
 
+    public AzureBlobStorageUploadRequest WithRemoteFileName(string fileName)
+    {
+        this.RemoteFileName = fileName;
+        return this;
+    }
 
     public AzureBlobStorageUploadRequest WithSasToken(string sasToken)
     {
@@ -86,7 +92,9 @@ public class AzureBlobStorageUploadRequest(string localFilePath)
         this.Headers.Add("x-ms-blob-type", "BlockBlob");
         
         var fileName = Path.GetFileName(this.LocalFilePath);
-        this.Headers.Add("Content-Disposition", $"attachment; filename=\"{fileName}\"");
+        var fn = this.RemoteFileName ?? fileName;
+        this.Headers.Add("Content-Disposition", $"attachment; filename=\"{fn}\"");
+        uri += "/" + fn;
 
         if (this.SasToken != null)
         {


### PR DESCRIPTION
This pull request enhances the `AzureBlobStorageUploadRequest` class by adding support for specifying a custom remote file name when uploading to Azure Blob Storage. This allows users to control the destination file name independently of the local file name. The main changes are:

**Support for custom remote file names:**

* Added a new `RemoteFileName` property to the `AzureBlobStorageUploadRequest` class, allowing users to specify the file name to use on Azure Blob Storage.
* Introduced a `WithRemoteFileName(string fileName)` method for fluent configuration of the remote file name.
* Updated the `Build()` method to use `RemoteFileName` (if set) for both the `Content-Disposition` header and the upload URI, defaulting to the local file name if not specified.…ow customization

### Description of Change ###

<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- All
- iOS
- Android
- UWP

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
- [ ] Sent to a v(branch) or DEV branch