### PR TITLE
Fix #1406 - Request scheduled permissions properly

### DIFF
--- a/src/Shiny.Notifications/Platforms/Android/NotificationManager.cs
+++ b/src/Shiny.Notifications/Platforms/Android/NotificationManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using Android.Content;
@@ -102,34 +103,57 @@ public partial class NotificationManager : INotificationManager,
         if (OperatingSystemShim.IsAndroidVersionAtLeast(33))
             list.Add(P.PostNotifications); // required
 
-        if (OperatingSystemShim.IsAndroidVersionAtLeast(31) && access.HasFlag(AccessRequestFlags.TimeSensitivity))
-            list.Add(P.ScheduleExactAlarm); // if denied, restricted
-
         if (access.HasFlag(AccessRequestFlags.LocationAware))
             list.AddRange(new[] { P.AccessCoarseLocation, P.AccessFineLocation }); // required, along with access bg
-        
-        var result = await this.platform.RequestPermissions(list.ToArray()).ToTask();
-        if (list.Contains(P.PostNotifications) && !result.IsGranted(P.PostNotifications))
-            return AccessState.Denied;
 
-        if (access.HasFlag(AccessRequestFlags.LocationAware))
+        if (list.Count > 0)
         {
-            if (!result.IsGranted(P.AccessFineLocation))
+            var result = await this.platform.RequestPermissions(list.ToArray()).ToTask();
+            if (list.Contains(P.PostNotifications) && !result.IsGranted(P.PostNotifications))
                 return AccessState.Denied;
 
-            if (OperatingSystemShim.IsAndroidVersionAtLeast(29))
+            if (access.HasFlag(AccessRequestFlags.LocationAware))
             {
-                var bgResult = await this.platform.RequestAccess(P.AccessBackgroundLocation).ToTask();
-                if (bgResult != AccessState.Available)
+                if (!result.IsGranted(P.AccessFineLocation))
                     return AccessState.Denied;
+
+                if (OperatingSystemShim.IsAndroidVersionAtLeast(29))
+                {
+                    var bgResult = await this.platform.RequestAccess(P.AccessBackgroundLocation).ToTask();
+                    if (bgResult != AccessState.Available)
+                        return AccessState.Denied;
+                }
             }
         }
 
         if (!this.manager.NativeManager.AreNotificationsEnabled())
             return AccessState.Disabled;
 
-        if (list.Contains(P.ScheduleExactAlarm) && !result.IsGranted(P.ScheduleExactAlarm))
-            return AccessState.Restricted;
+        // SCHEDULE_EXACT_ALARM is a special app-op permission, not a runtime permission
+        // It must be checked via AlarmManager.CanScheduleExactAlarms() and granted via Settings
+        if (OperatingSystemShim.IsAndroidVersionAtLeast(31) && access.HasFlag(AccessRequestFlags.TimeSensitivity))
+        {
+            if (!this.manager.Alarms.CanScheduleExactAlarms())
+            {
+                var intent = new Intent(
+                    Android.Provider.Settings.ActionRequestScheduleExactAlarm,
+                    Android.Net.Uri.Parse("package:" + this.platform.AppContext.PackageName)
+                );
+                intent.AddFlags(Android.Content.ActivityFlags.NewTask);
+                this.platform.AppContext.StartActivity(intent);
+
+                // wait for the user to return from settings
+                await this.platform
+                    .WhenActivityStatusChanged()
+                    .Where(x => x.State == ActivityState.Resumed)
+                    .Take(1)
+                    .ToTask()
+                    .ConfigureAwait(false);
+
+                if (!this.manager.Alarms.CanScheduleExactAlarms())
+                    return AccessState.Restricted;
+            }
+        }
 
         return AccessState.Available;
     }


### PR DESCRIPTION
This pull request updates the Android notification permission handling logic to better align with platform requirements, especially for the `SCHEDULE_EXACT_ALARM` permission. The most important changes are:

**Android Permission Handling Improvements:**

* The check and request for `SCHEDULE_EXACT_ALARM` permission has been refactored: it's no longer treated as a standard runtime permission but is now correctly checked using `AlarmManager.CanScheduleExactAlarms()`. If not granted, the user is directed to the appropriate system settings screen, and the app waits for them to return before re-checking the permission.
* The unnecessary addition of `SCHEDULE_EXACT_ALARM` to the runtime permission request list has been removed, preventing redundant or incorrect permission prompts.

**Codebase Enhancements:**

* Added `System.Reactive.Linq` import to support new reactive operations used in the permission flow.### Description of Change ###

<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- All
- iOS
- Android
- UWP

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
- [ ] Sent to a v(branch) or DEV branch