### PR TITLE
Fix Windows BLE state cleanup after disconnect and reconnect(#1613)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "dotnet.defaultSolution": "Shiny.sln"
+     "dotnet.defaultSolution": "Shiny.slnx"
 }

--- a/src/Shiny.BluetoothLE/Platforms/Windows/BleManager.cs
+++ b/src/Shiny.BluetoothLE/Platforms/Windows/BleManager.cs
@@ -232,6 +232,12 @@ public partial class BleManager : IBleManager, IShinyStartupTask
     }
 
 
+    internal void RemovePeripheral(Peripheral peripheral)
+    {
+        this.peripherals.TryRemove(peripheral.BluetoothAddress, out _);
+    }
+
+
     void Clear() => this.peripherals
         .Where(x => x.Value.Status != ConnectionState.Connected)
         .ToList()

--- a/src/Shiny.BluetoothLE/Platforms/Windows/Peripheral.cs
+++ b/src/Shiny.BluetoothLE/Platforms/Windows/Peripheral.cs
@@ -1,10 +1,13 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using Microsoft.Extensions.Logging;
 using Windows.Devices.Bluetooth;
 using Windows.Devices.Enumeration;
+using Windows.Devices.Bluetooth.GenericAttributeProfile;
 
 namespace Shiny.BluetoothLE;
 
@@ -16,6 +19,7 @@ public partial class Peripheral : IPeripheral
     readonly Subject<ConnectionState> connSubj = new();
     readonly Subject<BleException> connFailedSubj = new();
     readonly Subject<Unit> servicesChangedSubj = new();
+    readonly HashSet<GattDeviceService> trackedServices = new();
 
 
     public Peripheral(BleManager manager, BluetoothLEDevice device, ILogger<IPeripheral> logger)
@@ -23,6 +27,7 @@ public partial class Peripheral : IPeripheral
         this.manager = manager;
         this.logger = logger;
         this.Native = device;
+        this.BluetoothAddress = device.BluetoothAddress;
         this.Uuid = device.GetDeviceId().ToString();
 
         this.HookNativeEvents();
@@ -30,6 +35,7 @@ public partial class Peripheral : IPeripheral
 
 
     public BluetoothLEDevice? Native { get; private set; }
+    public ulong BluetoothAddress { get; }
     public DeviceInformation DeviceInfo => this.Native!.DeviceInformation;
     public string Uuid { get; }
     public string? Name => this.Native?.Name;
@@ -113,16 +119,7 @@ public partial class Peripheral : IPeripheral
             return;
 
         this.connSubj.OnNext(ConnectionState.Disconnecting);
-
-        this.ClearNotifications();
-
-        foreach (var service in this.Native.GattServices)
-        {
-            service.Session?.Dispose();
-            service.Dispose();
-        }
-        this.Native.Dispose();
-        this.Native = null;
+        this.ReleaseNativeResources();
 
         this.connSubj.OnNext(ConnectionState.Disconnected);
         this.manager.FirePeripheralStateChanged(this);
@@ -166,7 +163,10 @@ public partial class Peripheral : IPeripheral
         this.logger.LogDebug("Peripheral {Uuid} connection status changed to {State}", this.Uuid, state);
 
         if (state == ConnectionState.Disconnected)
-            this.ClearNotifications();
+        {
+            this.ReleaseNativeResources();
+            this.manager.RemovePeripheral(this);
+        }
 
         this.connSubj.OnNext(state);
         this.manager.FirePeripheralStateChanged(this);
@@ -184,5 +184,48 @@ public partial class Peripheral : IPeripheral
     {
         if (this.Status != ConnectionState.Connected)
             throw new InvalidOperationException("GATT is not connected");
+    }
+
+
+    protected GattDeviceService TrackService(GattDeviceService service)
+    {
+        lock (this.trackedServices)
+            this.trackedServices.Add(service);
+
+        return service;
+    }
+
+
+    void ReleaseNativeResources(bool disposeNative = true)
+    {
+        this.ClearNotifications();
+
+        List<GattDeviceService> services;
+        lock (this.trackedServices)
+        {
+            services = this.trackedServices.ToList();
+            this.trackedServices.Clear();
+        }
+
+        foreach (var service in services)
+        {
+            try
+            {
+                service.Session?.Dispose();
+                service.Dispose();
+            }
+            catch
+            {
+                // best effort cleanup
+            }
+        }
+
+        if (disposeNative && this.Native != null)
+        {
+            this.Native.ConnectionStatusChanged -= this.OnConnectionStatusChanged;
+            this.Native.GattServicesChanged -= this.OnGattServicesChanged;
+            this.Native.Dispose();
+            this.Native = null;
+        }
     }
 }

--- a/src/Shiny.BluetoothLE/Platforms/Windows/Peripheral_Characteristics.cs
+++ b/src/Shiny.BluetoothLE/Platforms/Windows/Peripheral_Characteristics.cs
@@ -32,6 +32,7 @@ public partial class Peripheral
 
         var service = result.Services.FirstOrDefault()
             ?? throw new BleException($"Service '{serviceUuid}' not found");
+        this.TrackService(service);
 
         var chResult = await service
             .GetCharacteristicsAsync(BluetoothCacheMode.Uncached)
@@ -69,11 +70,14 @@ public partial class Peripheral
                 .Switch()
                 .Select(ch => Observable.Create<BleCharacteristicResult>(ob =>
                 {
+                    var characteristicInfo = ToCharInfo(ch);
+                    var notifyingInfo = ToCharInfo(ch, isNotifying: true);
+                    var notifyingOffInfo = ToCharInfo(ch, isNotifying: false);
+
                     var handler = new TypedEventHandler<GattCharacteristic, GattValueChangedEventArgs>((sender, args) =>
                     {
                         var data = args.CharacteristicValue?.ToArray();
-                        var info = ToCharInfo(sender);
-                        ob.OnNext(new BleCharacteristicResult(info, BleCharacteristicEvent.Notification, data));
+                        ob.OnNext(new BleCharacteristicResult(characteristicInfo, BleCharacteristicEvent.Notification, data));
                     });
 
                     ch.ValueChanged += handler;
@@ -92,8 +96,7 @@ public partial class Peripheral
                             }
                             else
                             {
-                                var info = ToCharInfo(ch, isNotifying: true);
-                                this.charSubChangedSubj.OnNext(info);
+                                this.charSubChangedSubj.OnNext(notifyingInfo);
                             }
                         });
 
@@ -107,8 +110,7 @@ public partial class Peripheral
                                 GattClientCharacteristicConfigurationDescriptorValue.None
                             ).AsTask().ContinueWith(_ =>
                             {
-                                var info = ToCharInfo(ch, isNotifying: false);
-                                this.charSubChangedSubj.OnNext(info);
+                                this.charSubChangedSubj.OnNext(notifyingOffInfo);
                             });
                         }
                         catch
@@ -234,6 +236,7 @@ public partial class Peripheral
 
         var service = result.Services.FirstOrDefault()
             ?? throw new BleException($"Service '{serviceUuid}' not found");
+        this.TrackService(service);
 
         var cuid = Utils.ToUuidType(characteristicUuid);
         var chResult = await service

--- a/src/Shiny.BluetoothLE/Platforms/Windows/Peripheral_Services.cs
+++ b/src/Shiny.BluetoothLE/Platforms/Windows/Peripheral_Services.cs
@@ -27,6 +27,7 @@ public partial class Peripheral
         if (service == null)
             throw new BleException($"Service '{serviceUuid}' not found");
 
+        this.TrackService(service);
         return new BleServiceInfo(service.Uuid.ToString());
     });
 
@@ -41,6 +42,9 @@ public partial class Peripheral
             .ConfigureAwait(false);
 
         result.Status.Assert("GetServices", "all");
+
+        foreach (var service in result.Services)
+            this.TrackService(service);
 
         return (IReadOnlyList<BleServiceInfo>)result
             .Services


### PR DESCRIPTION
Closes #1613

## Summary

This fixes Windows BLE cleanup when a peripheral is disconnected unexpectedly, reconnected, and then disconnected again from the app.

## Changes

- track GATT services opened through Windows service/characteristic discovery APIs
- release tracked GATT resources during disconnect cleanup
- snapshot characteristic info for notification callbacks to avoid accessing disposed WinRT objects during teardown
- dispose the old `BluetoothLEDevice` and remove the cached peripheral when Windows reports a physical disconnect

## Why

Before this change, Windows cleanup only disposed `Native.GattServices`, but the peripheral could also hold GATT services obtained from `GetGattServicesAsync` and `GetGattServicesForUuidAsync`. After a physical disconnect, the cached peripheral and native device could also be reused on reconnect.

That left stale Windows BLE state behind, which could cause the device to stop advertising after the app disconnected it following a reconnect.

## Validation

Tested with the reported flow:

1. connect to the device
2. trigger a physical disconnect
3. reconnect
4. disconnect from the app
5. scan again and verify the device advertises normally

### Description of Change ###

<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- All
- iOS
- Android
- UWP

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
- [ ] Sent to a v(branch) or DEV branch