### PR TITLE
Fix startup ANR: circular DI dependency deadlock in HttpClientHttpTransferProcess

### DIFF
--- a/src/Shiny.Net.Http/Infrastructure/HttpClientHttpTransferProcess.cs
+++ b/src/Shiny.Net.Http/Infrastructure/HttpClientHttpTransferProcess.cs
@@ -20,7 +20,7 @@ public class HttpClientHttpTransferProcess(
     ILogger<HttpClientHttpTransferProcess> logger,
     IRepository repository,
     IConnectivity connectivity,
-    IEnumerable<IHttpTransferDelegate> delegates,
+    IServiceProvider services,
     IHttpClientFactory httpClientFactory,
     TimeSpan? pollInterval = null
 )
@@ -184,8 +184,8 @@ public class HttpClientHttpTransferProcess(
                 .ConfigureAwait(false);
 
             logger.LogInformation("Completing Successful Transfer: " + transfer.Identifier);
-            await delegates
-                .RunDelegates(x => x.OnCompleted(transfer.Request), logger)
+            await services
+                .RunDelegates<IHttpTransferDelegate>(x => x.OnCompleted(transfer.Request), logger)
                 .ConfigureAwait(false);
 
             ProgressOccurred?.Invoke(null, new(
@@ -205,8 +205,8 @@ public class HttpClientHttpTransferProcess(
             repository.Remove(transfer);
 
             logger.LogError(ex, "There was an error processing transfer: " + transfer?.Identifier);
-            await delegates
-                .RunDelegates(x => x.OnError(transfer!.Request, ex.StatusCode == null ? 0 : (int)ex.StatusCode, ex), logger)
+            await services
+                .RunDelegates<IHttpTransferDelegate>(x => x.OnError(transfer!.Request, ex.StatusCode == null ? 0 : (int)ex.StatusCode, ex), logger)
                 .ConfigureAwait(false);
 
             ProgressOccurred?.Invoke(null, new(


### PR DESCRIPTION
## Summary

On the Android/Windows managed transfer path, `HttpClientHttpTransferProcess` takes `IEnumerable<IHttpTransferDelegate>` as a constructor dependency. But a delegate that derives from the `HttpTransferDelegate` base class — which the docs recommend, and which takes `IHttpTransferManager` — closes a dependency cycle:

```
HttpClientHttpTransferManager
  -> HttpClientHttpTransferProcess
    -> IEnumerable<IHttpTransferDelegate>
      -> (your delegate : HttpTransferDelegate)
        -> IHttpTransferManager
          -> HttpClientHttpTransferManager ...
```

Normally the container would throw `A circular dependency was detected`. It doesn't here, because `AddSingletonAsImplementedInterfaces` registers everything through factory forwarders (`sp => sp.GetRequiredService<T>()`), which are opaque to MSDI's cycle detection. Instead, resolution recurses until `StackGuard.RunOnEmptyStack` spills the continuation onto a thread-pool thread — and then the singleton root-cache locks deadlock between the original thread (holding the lock, blocked on `WaitHandle.WaitOne`) and the offloaded thread (blocked trying to take the same lock).

On .NET MAUI Android this hangs the **main thread** during `CreateMauiApp()`, so the app never finishes startup and Android kills it with a "failed to complete startup" ANR before any UI renders. It reproduces 100% of the time as soon as a `HttpTransferDelegate`-derived delegate is registered.

## The deadlocked stack

Captured with `dotnet-stack` against the hung process (trimmed):

```
Thread A (origin):
  WaitHandle.WaitOne()
  StackGuard.RunOnEmptyStackCore(...)
  CallSiteRuntimeResolver.Resolve(...)
  ...FactoryCallSite -> DIExtensions<HttpClientHttpTransferManager>.<AddSingletonAsImplementedInterfaces>b__0_1
  ...FactoryCallSite -> DIExtensions<InvoiceUploadTransferDelegate>.<AddSingletonAsImplementedInterfaces>b__0_1   (via IEnumerable<IHttpTransferDelegate>)
  ...  (cycle repeats)

Thread B (StackGuard-offloaded worker):
  CallSiteRuntimeResolver.VisitRootCache(...)   // blocked taking the singleton lock Thread A holds
```

## Fix

Resolve the delegates lazily from `IServiceProvider` at the point of use — exactly what the Apple `HttpTransferManager` already does (`services.RunDelegates<IHttpTransferDelegate>(...)`). The manager singleton is fully constructed and cached by the time the transfer loop actually runs, so resolving a delegate no longer re-enters manager construction and the cycle is broken.

This is internal to the managed transfer process — no public API change.

## Verification

Reproduced and fixed on a real .NET MAUI Android app (a `HttpTransferDelegate`-derived upload delegate + `AddHttpTransfers`). Same app, same flag, same Shiny 5.0.0 assembly version — the only variable is this patch:

| Build | Result |
|-------|--------|
| Unpatched `Shiny.Net.Http` | `am_anr: failed to complete startup` → process killed |
| Patched (this PR) | Launches clean, stable, no ANR |

Verified on both a physical device (Galaxy S25, Android 16) and an Android 35 emulator.
