### PR TITLE
Fix Android AddHttpTransfers: run transfers in the dataSync foreground service

### DIFF
--- a/src/Shiny.Net.Http/ServiceCollectionExtensions.cs
+++ b/src/Shiny.Net.Http/ServiceCollectionExtensions.cs
@@ -15,7 +15,19 @@ public static class HttpTransferServiceCollectionExtensions
     {
 #if IOS || MACCATALYST
         services.AddSingletonAsImplementedInterfaces<HttpTransferManager>();
-#elif ANDROID || WINDOWS
+#elif ANDROID
+        // Register the Android platform HttpTransferManager so transfers run inside
+        // the dataSync foreground service (HttpTransferService) the package ships.
+        // Registering HttpClientHttpTransferManager here instead runs the transfer
+        // loop as an in-process Task.Run: transfers don't survive backgrounding and
+        // the loop's isRunning flag stalls after its first batch ("N uploaded then
+        // everything stuck Pending"). The FGS still resolves
+        // HttpClientHttpTransferProcess + the named HttpClient from DI to move the
+        // bytes, so those registrations stay.
+        services.AddSingletonAsImplementedInterfaces<HttpTransferManager>();
+        services.AddSingleton<HttpClientHttpTransferProcess>();
+        services.AddHttpClient(HttpClientHttpTransferProcess.HttpClientName);
+#elif WINDOWS
         services.AddSingletonAsImplementedInterfaces<HttpClientHttpTransferManager>();
         services.AddSingleton<HttpClientHttpTransferProcess>();
         services.AddHttpClient(HttpClientHttpTransferProcess.HttpClientName);


### PR DESCRIPTION
## Summary

On Android, `AddHttpTransfers<TDelegate>()` registers `HttpClientHttpTransferManager` — the managed fallback whose transfer loop runs in-process via `Task.Run`. Two problems fall out of that on a phone:

1. **Transfers don't survive backgrounding.** The loop lives in the app process with nothing holding it alive, so Android freezing/killing the process stalls (or loses) every queued transfer.
2. **A transfer queued while the loop is draining can be missed.** `TryStartProcess` is gated by a static `isRunning` flag that only resets after the loop exits. A `Queue()` landing in that window sees `isRunning == true` and doesn't start a new loop — but the finishing loop never re-reads the repository, so the transfer sits `Pending` until the *next* `Queue()` call happens to restart things. In the field this presents as "first batch uploads, everything after sticks in Pending".

The package already ships the machinery that solves both: the Android platform `HttpTransferManager` starts `HttpTransferService`, a `dataSync` foreground service that runs `HttpClientHttpTransferProcess` under OS ownership — with intent redelivery after a process kill, and the manager's startup task re-arming the service whenever pending transfers exist. It just isn't the manager `AddHttpTransfers()` registers.

## Fix

Register the platform `HttpTransferManager` on Android, keeping the `HttpClientHttpTransferProcess` + named `HttpClient` registrations the service resolves from DI. Windows keeps `HttpClientHttpTransferManager`; iOS/MacCatalyst untouched.

One consumer note that may be worth a docs mention: Android 14+ requires `FOREGROUND_SERVICE_DATA_SYNC` in the app manifest, otherwise the service start throws `SecurityException`.

## Verification

Same production MAUI Android app as #1633 (invoice-scan uploads through a `HttpTransferDelegate`-derived delegate), same assembly version, only this patch varying:

| Build | Result |
|-------|--------|
| Unpatched `Shiny.Net.Http` | uploads stall when the app backgrounds; queue wedges after the first drain |
| Patched (this PR) | transfers run in the dataSync FGS, survive backgrounding and process kill, queue drains continuously |

Running in production since 2026-07-01 as a vendored patch on 5.0.x. Verified on a physical device (Galaxy S25, Android 16) and an Android 35 emulator. Follow-up to #1633.