### PR TITLE
Android: opt-in shortService FGS type + implement onTimeout (required by Android 15's dataSync limits)

### DIFF
--- a/src/Shiny.Net.Http/Platforms/Android/HttpTransferService.cs
+++ b/src/Shiny.Net.Http/Platforms/Android/HttpTransferService.cs
@@ -2,6 +2,7 @@
 using Android.Content;
 using Android.Content.PM;
 using Android.OS;
+using Microsoft.Extensions.Logging;
 using Shiny.Net.Http.Infrastructure;
 
 namespace Shiny.Net.Http;
@@ -15,7 +16,26 @@ namespace Shiny.Net.Http;
 public class HttpTransferService : ShinyAndroidForegroundService<IHttpTransferManager, IHttpTransferDelegate>
 {
     public static bool IsStarted { get; private set; }
-    protected override ForegroundService StartForegroundServiceType => ForegroundService.TypeDataSync;
+
+    /// <summary>
+    /// When true (and the device runs Android 14+), the service promotes itself as
+    /// FOREGROUND_SERVICE_TYPE_SHORT_SERVICE instead of dataSync. shortService needs
+    /// no type-specific manifest permission and no Google Play foreground-service
+    /// declaration, at the cost of a ~3 minute run window per promotion (extended
+    /// while the app is visible). Suits apps whose transfers are brief bursts —
+    /// pending transfers survive a timeout in the repository and the service is
+    /// re-armed on the next Queue()/app start. Apps opting in can also strip
+    /// android:foregroundServiceType + FOREGROUND_SERVICE_DATA_SYNC from their
+    /// merged manifest (shortService does not need to be declared).
+    /// On Android 13 and lower this flag is ignored (the type does not exist there;
+    /// pre-14 devices keep dataSync).
+    /// </summary>
+    public static bool UseShortService { get; set; }
+
+    protected override ForegroundService StartForegroundServiceType =>
+        UseShortService && OperatingSystem.IsAndroidVersionAtLeast(34)
+            ? ForegroundService.TypeShortService
+            : ForegroundService.TypeDataSync;
 
 
     protected override void OnStart(Intent? intent)
@@ -29,6 +49,25 @@ public class HttpTransferService : ShinyAndroidForegroundService<IHttpTransferMa
 
 
     protected override void OnStop() => IsStarted = false;
+
+    /// <summary>
+    /// The OS says this service's time is up: shortService gets ~3 minutes per
+    /// promotion (API 34+), and Android 15 caps dataSync at a 6-hour daily budget —
+    /// both deliver onTimeout, and NOT stopping promptly is an ANR
+    /// ("A foreground service of ... did not stop within its timeout").
+    /// Pending transfers stay in the repository; the manager re-arms the service on
+    /// the next Queue() or app start, so a timeout defers work instead of losing it.
+    /// </summary>
+    public override void OnTimeout(int startId)
+    {
+        this.Logger.LogWarning(
+            "HttpTransferService hit its foreground-service time limit — stopping; pending transfers resume on the next service start");
+        this.Stop();
+    }
+
+    /// <inheritdoc cref="OnTimeout(int)"/>
+    public override void OnTimeout(int startId, ForegroundService fgsType)
+        => this.OnTimeout(startId);
 
     public override IBinder? OnBind(Intent? intent) => null;
 }

--- a/src/Shiny.Net.Http/Platforms/Android/HttpTransferService.cs
+++ b/src/Shiny.Net.Http/Platforms/Android/HttpTransferService.cs
@@ -33,7 +33,7 @@ public class HttpTransferService : ShinyAndroidForegroundService<IHttpTransferMa
     public static bool UseShortService { get; set; }
 
     protected override ForegroundService StartForegroundServiceType =>
-        UseShortService && OperatingSystem.IsAndroidVersionAtLeast(34)
+        UseShortService && System.OperatingSystem.IsAndroidVersionAtLeast(34)
             ? ForegroundService.TypeShortService
             : ForegroundService.TypeDataSync;
 


### PR DESCRIPTION
## Summary

Two related Android changes to `HttpTransferService`, both driven by where Google is pushing foreground services:

1. **Opt-in `shortService` promotion** — `HttpTransferService.UseShortService = true` promotes the service as `FOREGROUND_SERVICE_TYPE_SHORT_SERVICE` (Android 14+) instead of `dataSync`. Default is unchanged, and Android 13-and-lower devices ignore the flag (the type doesn't exist there).
2. **Implement `Service.onTimeout`** — always, regardless of the flag. Today the service doesn't handle it, and the OS response to an unhandled timeout is an ANR: *"A foreground service of ... did not stop within its timeout"*.

## Why shortService

For apps whose transfers are short bursts (upload a scan, sync a batch), `dataSync` is becoming an expensive type to carry:

- It requires `FOREGROUND_SERVICE_DATA_SYNC` in the manifest, and Google Play requires a **policy declaration** for it (use-case selection + written description + a demo video) before release to reviewed tracks. `shortService` is not on Play's declaration list and needs no type-specific permission — an app can strip both from its merged manifest (shortService doesn't have to be declared).
- **Android 15 put `dataSync` on a clock anyway**: a ~6-hour daily budget, delivered through the same `onTimeout` callback. The "no timeout" advantage dataSync had over shortService is going away release by release.

The trade: shortService gets ~3 minutes per promotion (extended while the app is visible). That's a fit for burst-transfer apps and a bad fit for long downloads — hence opt-in, not a new default.

## Timeout handling

On `onTimeout` (both the API 34 shortService overload and the API 35 typed one) the service logs and stops cleanly. Pending transfers stay in the repository, and the existing machinery re-arms the service on the next `Queue()` or app start — so a timeout defers work instead of losing it, and instead of ANRing.

## Verification

Compiles against net10.0-android (API 35+ bindings; `OnTimeout(int)` is ApiSince=34, the typed overload ApiSince=35). We run invoice-scan uploads through this service in production (see #1633 / #1634 for the app context); transfers are single-digit-second bursts, comfortably inside the shortService window.

Related: #1634 (registering this service on Android at all).