### PR TITLE
Android: resolve a persisted peripheral without a scan

### DIFF
--- a/src/Shiny.BluetoothLE/IBleManager.cs
+++ b/src/Shiny.BluetoothLE/IBleManager.cs
@@ -21,7 +21,12 @@ public interface IBleManager
     IObservable<AccessState> RequestAccess();
 
     /// <summary>
-    /// Returns a previously seen peripheral by its identifier, or null if it has not been observed in this session.
+    /// Returns a peripheral by its identifier, or null when it cannot be resolved. A peripheral seen in
+    /// this session is returned from cache; otherwise the platform is asked, so a caller holding a
+    /// persisted identifier can reconnect after a process restart without scanning again. Whether an
+    /// unseen peripheral resolves is platform-dependent — Apple consults CoreBluetooth's known
+    /// peripherals, Android reconstructs the device from the identifier's address, and Windows resolves
+    /// only from cache.
     /// </summary>
     /// <param name="peripheralUuid">The platform-specific peripheral identifier.</param>
     /// <returns>The known peripheral instance, or null when not found.</returns>

--- a/src/Shiny.BluetoothLE/Platforms/Android/BleManager.cs
+++ b/src/Shiny.BluetoothLE/Platforms/Android/BleManager.cs
@@ -219,7 +219,23 @@ public partial class BleManager : ScanCallback, IBleManager, IShinyStartupTask
         => this.peripherals.Where(x => x.Value.Status == ConnectionState.Connected).Select(x => x.Value);
 
     public IPeripheral? GetKnownPeripheral(string peripheralUuid)
-        => this.peripherals.Values.FirstOrDefault(x => x.Uuid.Equals(peripheralUuid, StringComparison.InvariantCultureIgnoreCase));
+    {
+        var cached = this.peripherals.Values.FirstOrDefault(x => x.Uuid.Equals(peripheralUuid, StringComparison.InvariantCultureIgnoreCase));
+        if (cached != null)
+            return cached;
+
+        // Ask the adapter for the device so callers can reconnect by identifier after a process
+        // restart without burning battery on a scan, matching what Apple does with
+        // RetrievePeripheralsWithIdentifiers. Android offers no "has the OS seen this device"
+        // query for unbonded LE devices, so any identifier this platform could have produced
+        // resolves here; one that is not actually reachable fails at connect instead.
+        var address = Peripheral.GetAddress(peripheralUuid);
+        if (address == null)
+            return null;
+
+        var native = this.Native.Adapter?.GetRemoteDevice(address);
+        return native == null ? null : this.GetPeripheral(native);
+    }
 
     public override void OnScanResult([GeneratedEnum] ScanCallbackType callbackType, SR? result)
         => this.scanSubj.OnNext((result, null));

--- a/src/Shiny.BluetoothLE/Platforms/Android/Peripheral.cs
+++ b/src/Shiny.BluetoothLE/Platforms/Android/Peripheral.cs
@@ -283,6 +283,27 @@ public partial class Peripheral : BluetoothGattCallback, IPeripheral
     }
 
 
+    // The inverse of GetUuid. GetUuid parks the six MAC bytes in the last six bytes of the GUID,
+    // which a GUID renders verbatim as its final group, so the encoding is lossless and an
+    // identifier this platform produced round-trips back to an address BluetoothAdapter accepts.
+    // Returns null for anything not shaped like one of our identifiers.
+    internal static string? GetAddress(string peripheralUuid)
+    {
+        if (!Guid.TryParse(peripheralUuid, out var guid))
+            return null;
+
+        var bytes = guid.ToByteArray();
+        for (var i = 0; i < 10; i++)
+        {
+            if (bytes[i] != 0)
+                return null;
+        }
+
+        // BluetoothAdapter.CheckBluetoothAddress requires the upper-case AA:BB:CC:DD:EE:FF form.
+        return String.Join(':', bytes.Skip(10).Select(x => x.ToString("X2")));
+    }
+
+
     protected void AssertConnection()
     {
         if (this.Status != ConnectionState.Connected)


### PR DESCRIPTION
### Description of Change ###

On Android, `GetKnownPeripheral` only searched the in-process `peripherals` cache:

```csharp
public IPeripheral? GetKnownPeripheral(string peripheralUuid)
    => this.peripherals.Values.FirstOrDefault(x => x.Uuid.Equals(peripheralUuid, StringComparison.InvariantCultureIgnoreCase));
```

That cache is populated only by `GetPeripheral(BluetoothDevice)` from `FromNative(ScanResult)`, i.e. only by a scan in the current process, so after a process restart it is empty and the lookup can never hit. Reconnecting to a persisted identifier therefore required a scan on every cold start. Apple already falls back to `RetrievePeripheralsWithIdentifiers` for exactly this case (`e98b9828`).

Android has the equivalent primitive in `BluetoothAdapter.GetRemoteDevice(address)`, and it is reachable because the platform's peripheral identifier is a lossless encoding of the MAC: `Peripheral.GetUuid` parks the six address bytes in `deviceGuid[10..16]`, which a GUID renders verbatim as its final group. So:

- **`Peripheral.GetAddress(string)`** — the inverse of `GetUuid`. Parses the identifier, requires the first ten bytes to be zero (so anything not shaped like one of our identifiers is rejected rather than turned into a bogus address), and formats the last six as the upper-case `AA:BB:CC:DD:EE:FF` form `BluetoothAdapter.CheckBluetoothAddress` requires.
- **`BleManager.GetKnownPeripheral`** — cache first, then `GetAddress` + `Adapter?.GetRemoteDevice(address)` + the existing `GetPeripheral(BluetoothDevice)`, so the returned peripheral is the same cached instance any later scan would hand back.

Shaped to match the Apple implementation: same cache-then-platform order, same "reject a malformed identifier by returning null" guard.

### One behavioural note worth your call

Android has no "has the OS seen this device" query for **unbonded** LE devices — `BondedDevices` and `GetConnectedDevices` both miss the common case. So `GetRemoteDevice` returns a `BluetoothDevice` for any well-formed address, which means Android's `GetKnownPeripheral` now returns non-null for any identifier this platform could have produced, rather than proving reachability. A peripheral that is not actually around fails at connect instead of at lookup.

I think that is the right trade — the alternative is the status quo, where the method is unusable for its stated purpose on Android — but if you would rather have it behind an opt-in, or gated on `BondedDevices` for paired devices only, say the word and I will rework it.

### Verification

- `dotnet build src/Shiny.BluetoothLE/Shiny.BluetoothLE.csproj -f net10.0-android` — 0 errors, no new warnings.
- The `GetUuid` / `GetAddress` round-trip was verified out-of-band over a set of addresses (all-zero, all-FF, and ordinary ones), including that non-Shiny GUIDs and non-GUID strings are rejected. All the test projects target `net10.0` only, so there is no home in the repo for a test of Android platform code — happy to move `GetAddress` somewhere platform-neutral and add real tests if you would prefer that.

Reported by a consumer hitting this in a MAUI app: persisted BLE receiver, force-quit, relaunch, no auto-reconnect on Android while the same code reconnects on iOS.

### Issues Resolved ###

- fixes #1645

### API Changes ###

None. `Peripheral.GetAddress` is `internal static`.

The XML doc on `IBleManager.GetKnownPeripheral` said *"or null if it has not been observed in this session"*, which no longer described Apple after `e98b9828` and does not describe Android after this change, so I updated it to state the actual per-platform behaviour. Doc comment only, no signature change.
