### PR TITLE
Android: re-issue ConnectGatt after a dropped link

### DIFF
--- a/src/Shiny.BluetoothLE/Platforms/Android/Peripheral.cs
+++ b/src/Shiny.BluetoothLE/Platforms/Android/Peripheral.cs
@@ -19,6 +19,7 @@ public partial class Peripheral : BluetoothGattCallback, IPeripheral
     readonly BleManager manager;
     readonly IOperationQueue operations;
     readonly ILogger logger;
+    IDisposable? autoReconnectSub;
 
 
     public Peripheral(
@@ -66,6 +67,13 @@ public partial class Peripheral : BluetoothGattCallback, IPeripheral
 
     public void CancelConnection()
     {
+        // Disposed ahead of the Gatt null-check on purpose. After a dropped link Gatt is already
+        // null, so returning early with the subscription still live would let the auto-reconnect
+        // undo an explicit cancel. It also has to happen before the EmitConnectionState below,
+        // which would otherwise trip the reconnect itself.
+        this.autoReconnectSub?.Dispose();
+        this.autoReconnectSub = null;
+
         var gatt = this.Gatt;
         if (gatt == null)
             return;
@@ -90,16 +98,64 @@ public partial class Peripheral : BluetoothGattCallback, IPeripheral
 
     public void Connect(ConnectionConfig? config)
     {
+        AndroidConnectionConfig cfg = null!;
+        if (config == null)
+            cfg = new();
+        else if (config is AndroidConnectionConfig cfg1)
+            cfg = cfg1;
+        else
+            cfg = new AndroidConnectionConfig(config.AutoConnect);
+
+        this.autoReconnectSub?.Dispose();
+        this.autoReconnectSub = null;
+
+        if (cfg.AutoConnect)
+            this.ArmAutoReconnect(cfg);
+
+        this.DoConnect(cfg);
+    }
+
+
+    /// <summary>
+    /// Re-issues ConnectGatt after a dropped link, mirroring the Apple peripheral's autoReconnectSub.
+    /// </summary>
+    /// <remarks>
+    /// Android only keeps its own background reconnect pending while the GATT client stays open, and
+    /// OnConnectionStateChange has to close it on every disconnect to release the platform's 7-client
+    /// limit and to terminate in-flight operations. Nothing re-opened it afterwards, so a peripheral
+    /// that dropped out of range or was power-cycled stayed disconnected forever even with
+    /// AutoConnect set.
+    /// </remarks>
+    void ArmAutoReconnect(AndroidConnectionConfig cfg)
+        => this.autoReconnectSub = this
+            .WhenStatusChanged()
+            // Skip the value the BehaviorSubject replays on subscribe, and skip it BEFORE
+            // filtering - filtering first means a replayed Connected is what gets dropped and
+            // the first real disconnect is swallowed instead.
+            .Skip(1)
+            .Where(x => x == ConnectionState.Disconnected)
+            // A peripheral that rejects the reconnect can produce a status 133 connect/disconnect
+            // storm. Debouncing paces that at one attempt per second instead of a tight loop.
+            .Throttle(TimeSpan.FromSeconds(1))
+            .Subscribe(_ => this.DoReconnect(cfg));
+
+
+    void DoReconnect(AndroidConnectionConfig cfg)
+    {
+        // Both CancelConnection and CloseExistingGatt can emit a Disconnected while a fresh
+        // connect is already in flight; reconnecting on one of those would tear down a live link.
+        var status = this.Status;
+        if (status is ConnectionState.Connected or ConnectionState.Connecting)
+            return;
+
+        this.DoConnect(cfg);
+    }
+
+
+    void DoConnect(AndroidConnectionConfig cfg)
+    {
         try
         {
-            AndroidConnectionConfig cfg = null!;
-            if (config == null)
-                cfg = new();
-            else if (config is AndroidConnectionConfig cfg1)
-                cfg = cfg1;
-            else
-                cfg = new AndroidConnectionConfig(config.AutoConnect);
-
             // Close any prior GATT client before opening a new one — otherwise
             // each retry leaks a client and Android's 7-client limit kicks in,
             // producing status 133 on subsequent connects.


### PR DESCRIPTION
Fixes #1647.

`ConnectionConfig.AutoConnect` is documented as enabling automatic reconnection, but on Android nothing reconnected once a link actually dropped. `ConnectGatt`'s `autoConnect` flag only keeps a pending background reconnect **while the GATT client stays open**, and `OnConnectionStateChange` has to close that client on every disconnect — it is what releases the platform's 7-client limit and terminates in-flight operations. Nothing re-opened it, so a peripheral that was powered off or carried out of range stayed disconnected indefinitely.

Apple already handles this with the `autoReconnectSub` hooked in `Connect`. This gives Android the same subscription: the native connect moves out of `Connect` into `DoConnect`, `Connect` arms a `WhenStatusChanged` subscription when `AutoConnect` is set, and a disconnect re-issues `DoConnect`.

It restores the platform's own background reconnect rather than replacing it with a retry loop — one `ConnectGatt` is issued and Android holds it pending until the peripheral returns.

## Three details that are load-bearing

- **`CancelConnection` disposes the subscription before its early return on a null `Gatt`.** After a drop `Gatt` is already null, so returning first would leave the subscription live and let it undo an explicit cancel. It also has to run before `CancelConnection`'s own `EmitConnectionState(Disconnected)`, which would otherwise trip the reconnect.
- **`Skip(1)` runs before the `Disconnected` filter, not after.** `connSubj` is a `BehaviorSubject`, so subscribing replays the current state; filtering first means a replayed `Connected` is what `Skip` drops and the first real disconnect is swallowed. (The Apple implementation filters first — that is latent there, but I have left it alone rather than widen this PR.)
- **`DoReconnect` returns early when already `Connected` or `Connecting`.** Both `CancelConnection` and `CloseExistingGatt` can emit a `Disconnected` while a fresh connect is in flight, and reconnecting on one of those would tear down a live link.

## Two deliberate divergences from Apple

- **A `Throttle`.** A peripheral that rejects the reconnect can produce a status 133 connect/disconnect storm; debouncing paces that at one attempt per second instead of a tight loop.
- **No `WhenConnectionFailed` retry.** On Android a `ConnectGatt` failure is thrown synchronously, so retrying on it would spin for as long as the adapter is off. That is a separate concern from a dropped link and I would rather not fold it in here. Happy to add it if you want the platforms symmetrical.

## Verification

Built and run on hardware — Android 15, u-blox based Nano RTK Pro — with a build of this commit on top of 5.5.0 and no other change, so the delta is attributable to this alone.

```
15:13:07.110  GATT Connection State Change: <status> - Disconnected
15:13:08.142  status -> Connecting          <- the re-arm, ~1.03s after the drop
15:13:09.662  heartbeat: lastRawStatus=Connecting
15:13:14.673  heartbeat: lastRawStatus=Connecting
15:13:17.572  GATT Connection State Change: Success - Connected
15:13:18.384  notification payload resumes
```

The consuming app's own connect counter stayed at 1 across the whole window, so the reconnect came from this subscription and not from the caller. Exactly one `ConnectGatt` was issued and it stayed pending for the 9.4s the receiver was off. On stable 5.5.0 the same test leaves the peripheral `Disconnected` with no further connect attempt for as long as the test runs (131s captured, in #1647).

`dotnet build src/Shiny.BluetoothLE/Shiny.BluetoothLE.csproj -f net10.0-android -c Release` — 0 errors, no new warnings.

## Docs

No doc change proposed: `ConnectionConfig`'s summary and `skills/shiny-bluetoothle` already describe the behaviour this makes true. Tell me if you would like a release note in `release-notes.mdx` and I will add one.