### PR TITLE
Android: reset RequiresServiceDiscovery when a new GATT client is created

### DIFF
--- a/src/Shiny.BluetoothLE/Platforms/Android/Peripheral.cs
+++ b/src/Shiny.BluetoothLE/Platforms/Android/Peripheral.cs
@@ -170,6 +170,13 @@ public partial class Peripheral : BluetoothGattCallback, IPeripheral
             if (this.Gatt == null)
                 throw new BleException("GATT connection could not be established");
 
+            // A new client has discovered nothing, so reset here rather than relying on a teardown
+            // path having run first — turning the adapter off delivers no OnConnectionStateChange on
+            // some devices, so a consumer reconnecting from OnAdapterStateChanged arrives with the
+            // flag still false. GetNativeServices would then return this client's empty (not null)
+            // service list instead of discovering, and every lookup would throw for the connection's life.
+            this.RequiresServiceDiscovery = true;
+
             this.Gatt.RequestConnectionPriority(cfg.ConnectionPriority);
 
             this.EmitConnectionState(ConnectionState.Connecting);


### PR DESCRIPTION
Fixes #1650.

`DoConnect()` always creates a new `BluetoothGatt` via `ConnectGatt(...)`, but never reset `RequiresServiceDiscovery`. The flag is cleared back to `true` in only two places — `CancelConnection()` and `OnConnectionStateChange(.., Disconnected)` — so any `Connect()` that does not follow one of those leaves it stale from the previous client's discovery.

`BluetoothGatt.getServices()` on a fresh client returns an **empty, non-null** list until `onSearchComplete` populates it (AOSP initialises `mServices` in the constructor). So `GetNativeServices()` takes its short-circuit:

```csharp
if (!this.RequiresServiceDiscovery && this.Gatt?.Services != null)
    return this.Gatt!.Services!.ToList();
```

returns the empty list, and never issues `refresh()` / `discoverServices()`. `GetNativeService()` then throws `No service found with uuid: ...` for the lifetime of the connection — and since `GetNativeCharacteristic()` goes through it, every read, write and notify fails the same way. There is no recovery short of `CancelConnection()` + `Connect()`.

### The fix

One line, next to the assignment it is about:

```csharp
this.Gatt = this.Native.ConnectGatt(...);
if (this.Gatt == null)
    throw new BleException("GATT connection could not be established");

this.RequiresServiceDiscovery = true;
```

Placing it here rather than in `CloseExistingGatt()` makes the invariant local to the single place `Gatt` is assigned, instead of depending on every teardown path having run first. A new client has by definition discovered nothing, so the flag is unconditionally stale at that point.

### How it shows up

An OS-level Bluetooth power cycle. On some devices the framework delivers **no** `OnConnectionStateChange` for the power-down — verified from a full logcat capture where Shiny logs every invocation of that override and none appears, and only two `onClientConnectionState` callbacks occur in the whole session, both `connected=true`. `Gatt` stays non-null and the flag stays `false`.

A consumer then re-establishes the link from `IBleDelegate.OnAdapterStateChanged(AccessState.Available)` — the documented hook for exactly this — and lands in `DoConnect()` with the stale flag. Observed on a Samsung Galaxy A37 against `5.6.0-beta-0071`: the link genuinely comes back up and MTU negotiates, but every service lookup throws from that point on.

The same capture shows the asymmetry directly — the first connect runs `refresh()` → `Clear Internal Cache` → `discoverServices()` → `onSearchComplete`, and the reconnect runs none of it.

`ArmAutoReconnect` is **not** affected: it only fires on a `Disconnected` emission, and both producers of that emission reset the flag before emitting. The exposure is consumer-initiated `Connect()` on a peripheral whose previous client was never reported disconnected.

Also present in `5.5.0` stable — same code path, confirmed by decompiling that release's `net10.0-android36.0` assembly.

### Verification

`dotnet build src/Shiny.BluetoothLE/Shiny.BluetoothLE.csproj -f net10.0-android` — succeeds, 0 errors, and no warning references the changed file. (Built with `-p:MacOsTarget=` on a host without the `macos` workload; the change is Android-only and touches no other target.)

I have not run the fixed package on the device yet — the repro is a manual Bluetooth toggle. Happy to build a local package and confirm on the Galaxy A37 if you would like that before merging.
